### PR TITLE
fix(renovate): remove Talos custom managers to avoid duplicate PRs

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -29,23 +29,5 @@
       ],
       datasourceTemplate: "docker",
     },
-    {
-      customType: "regex",
-      description: "Match Talos factory installer images with version tags in YAML files",
-      managerFilePatterns: ["/\\.ya?ml$/"],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s+image: factory\\.talos\\.dev/installer/[a-f0-9]+:(?<currentValue>v\\S+)",
-      ],
-      datasourceTemplate: "github-releases",
-    },
-    {
-      customType: "regex",
-      description: "Match Talos factory installer images with version tags in Markdown files",
-      managerFilePatterns: ["/\\.md$/"],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.*factory\\.talos\\.dev/installer/[a-f0-9]+:(?<currentValue>v\\S+)",
-      ],
-      datasourceTemplate: "github-releases",
-    },
   ],
 }


### PR DESCRIPTION
The overridePackageName approach is cleaner and sufficient