### PR TITLE
fix(renovate): disable regex manager for siderolabs/talos

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -2,6 +2,12 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
+      description: "Disable regex manager for Talos (use override instead)",
+      matchManagers: ["regex"],
+      matchPackageNames: ["siderolabs/talos"],
+      enabled: false,
+    },
+    {
       description: "Override Talos Installer Package Name",
       matchDatasources: ["docker"],
       matchPackageNames: ["/factory\\.talos\\.dev/"],


### PR DESCRIPTION
Prevents duplicate PRs by disabling the annotated dependency regex manager for Talos. The overridePackageName approach is sufficient.