### PR TITLE
Revert "fix(renovate): disable regex manager for siderolabs/talos"

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -2,12 +2,6 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   packageRules: [
     {
-      description: "Disable regex manager for Talos (use override instead)",
-      matchManagers: ["regex"],
-      matchPackageNames: ["siderolabs/talos"],
-      enabled: false,
-    },
-    {
       description: "Override Talos Installer Package Name",
       matchDatasources: ["docker"],
       matchPackageNames: ["/factory\\.talos\\.dev/"],


### PR DESCRIPTION
This reverts commit a7d640a3a7053017279d170884037a55831c5f48.