### PR TITLE
fix: add Recreate strategy for deployments with ReadWriteOnce PVCs

### DIFF
--- a/kubernetes/apps/talos1018/bricktracker/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/bricktracker/app/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: bricktracker

--- a/kubernetes/apps/talos1018/homebox/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/homebox/app/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: homebox

--- a/kubernetes/apps/talos1018/mealie/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/mealie/app/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: mealie

--- a/kubernetes/apps/talos1018/spoolman/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/spoolman/app/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: spoolman


### PR DESCRIPTION
- Add strategy.type: Recreate to bricktracker, mealie, homebox, and spoolman
- Prevents pod scheduling deadlock during updates with RWO PVCs
- Ensures old pod terminates and releases PVC before new pod starts