### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-flux.yaml
+++ b/.github/workflows/validate-flux.yaml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   manifests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/fmurodov/homeops/security/code-scanning/5](https://github.com/fmurodov/homeops/security/code-scanning/5)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow to the least privilege needed. Since this workflow only validates manifests and does not write to the repo, issues, or PRs, it only needs read access to repository contents.

The best fix without changing functionality is to add a `permissions:` block that sets `contents: read`. You can add this either at the workflow root (to apply to all jobs) or at the `manifests` job level. To address the specific warning on the job line and to keep the change tightly scoped, place it at the job level under `manifests:` and before `runs-on:`. No imports or additional definitions are required; this is purely a YAML configuration change in `.github/workflows/validate-flux.yaml`, near line 15.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
