### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flux-e2e.yaml
+++ b/.github/workflows/flux-e2e.yaml
@@ -8,6 +8,9 @@ on:
   #   branches: ["*"]
   #   tags-ignore: ["*"]
 
+permissions:
+  contents: read
+
 jobs:
   kubernetes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fmurodov/homeops/security/code-scanning/4](https://github.com/fmurodov/homeops/security/code-scanning/4)

In general, the problem is fixed by explicitly specifying a minimal `permissions` block either at the top level of the workflow (applies to all jobs) or within each job that needs it. This overrides the repository default and ensures the `GITHUB_TOKEN` has only the scopes required by the workflow. For most read-only workflows that only need to fetch repository contents, `contents: read` is a sensible starting point.

For this specific workflow in `.github/workflows/flux-e2e.yaml`, the simplest and least intrusive fix is to add a `permissions` block at the workflow root (same indentation as `on:` and `jobs:`). The job uses the repository URL and `GITHUB_TOKEN` to configure a Flux Git source. That action only needs to read from the repository, so we can safely restrict the token to `contents: read`. No changes to the steps or actions are needed. Concretely, add:

```yaml
permissions:
  contents: read
```

between the `on:` block and `jobs:` (for example after line 10). This will ensure that the `kubernetes` job runs with a read-only `GITHUB_TOKEN` without altering existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
