### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-talos.yaml
+++ b/.github/workflows/validate-talos.yaml
@@ -1,5 +1,7 @@
 ---
 name: Validate Talos Configs
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/fmurodov/homeops/security/code-scanning/3](https://github.com/fmurodov/homeops/security/code-scanning/3)

In general, to fix this class of issue you explicitly define a `permissions` block at the workflow or job level, granting only the scopes actually needed. For a validation job that simply checks configuration files and doesn’t need to push commits, open issues, or modify PRs, `contents: read` is sufficient and recommended as a minimal starting point.

For this specific workflow in `.github/workflows/validate-talos.yaml`, the simplest and safest fix is to add a `permissions` block granting read-only access to repository contents. You can add it at the root (applies to all jobs) or under the `validate` job. Since there is only one job and no indication that any job requires broader rights, adding a root-level `permissions` block after the `name:` declaration is clear and concise:

```yaml
name: Validate Talos Configs
permissions:
  contents: read
```

No other functionality changes are needed: the steps remain the same, and `actions/checkout` works with read-only contents permissions for this use case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
