### PR TITLE
fix(ci): grant write permissions for claude-review to post PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # Changed from 'read' to 'write' to allow posting review comments
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary

Fixes the `claude-code-review` workflow to allow Claude to post review comments on pull requests.

## Problem

The workflow was running successfully but failing silently when attempting to post review comments due to insufficient GitHub token permissions. The workflow had `pull-requests: read` but needs `pull-requests: write` to post comments.

## Changes

- Changed `pull-requests` permission from `read` to `write` in `.github/workflows/claude-code-review.yml`

## Evidence

From the PR #136 workflow logs, Claude executed successfully and attempted to run:
```bash
gh pr review 136 --comment --body "..."
```

However, no comments appeared on the PR because the GitHub token lacked write permissions.

## Validation

According to [official documentation](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md), the required permissions for PR review workflows are:

```yaml
permissions:
  contents: read
  pull-requests: write  # ← Must be 'write', not 'read'
  id-token: write
```

## Test Plan

- [x] Validate workflow file syntax
- [ ] Verify workflow runs on new PRs
- [ ] Confirm Claude can post review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)