### PR TITLE
fix(ci): add --comment flag to code-review plugin command

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

Adds the `--comment` flag to the `code-review` plugin command to enable posting review comments to pull requests.

## Problem

After PR #143 fixed the permissions issue, Claude Code was still not posting review comments to PRs. The workflow logs showed that Claude was attempting to post comments, but they were being blocked by permission denials.

Investigation revealed that the `code-review` plugin requires an explicit `--comment` flag to post comments to PRs. Without this flag, the plugin only outputs the review to the terminal/logs.

## Changes

- Added `--comment` flag to the prompt: `/code-review:code-review --comment ...`

## Evidence

From the code-review plugin documentation:

**Without `--comment`**: Outputs the review to terminal only (default behavior)
**With `--comment`**: Posts the review as a comment on the pull request

## Validation

Compared with a working example from another repository (signal18/replication-manager) which confirmed this is a common pattern.

Reference: https://github.com/anthropics/claude-code/blob/main/plugins/code-review/README.md

## Test Plan

- [x] Validate workflow file syntax
- [ ] Verify workflow runs on new PRs (will test on PR #136)
- [ ] Confirm Claude can post review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)