### PR TITLE
fix(grafana): use public domain for OIDC auth_url

### DIFF
--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
         client_id: $${GF_OIDC_CLIENT_ID}
         client_secret: $${GF_OIDC_CLIENT_SECRET}
         scopes: openid profile email
-        auth_url: https://pid.${CLUSTER_DOMAIN}/authorize
+        auth_url: https://pid.${DOMAIN}/authorize
         token_url: https://pid.${CLUSTER_DOMAIN}/oauth2/token
         api_url: https://pid.${CLUSTER_DOMAIN}/userinfo
         auto_sign_up: true


### PR DESCRIPTION
## Summary
- Fixed Grafana OIDC `auth_url` to use `${DOMAIN}` instead of `${CLUSTER_DOMAIN}`
- The `auth_url` is a browser redirect, so it must use the public domain to match Pocket-ID's WebAuthn relying party ID (derived from `APP_URL`)
- `token_url` and `api_url` remain on `${CLUSTER_DOMAIN}` as they are server-to-server calls

## Test plan
- [ ] Login to Grafana via Pocket-ID SSO and verify "relying party ID is invalid" error is resolved
- [ ] Verify token exchange and userinfo still work over internal domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)