### PR TITLE
fix(fluent-bit): enable health endpoint and preserve log field for _msg

### DIFF
--- a/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
             Daemon        Off
             Log_Level     info
             Parsers_File  parsers.conf
+            HTTP_Server   On
+            HTTP_Listen   ::
+            HTTP_Port     2020
       inputs: |
         [INPUT]
             Name              tail
@@ -42,6 +45,7 @@ spec:
             Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
             Kube_Meta_Cache_TTL 300
             Merge_Log           On
+            Keep_Log            On
       outputs: |
         [OUTPUT]
             Name        loki


### PR DESCRIPTION
## Summary
- Enable HTTP health server on IPv6 (`::`) port 2020 so liveness/readiness probes succeed
- Add `Keep_Log On` to preserve the original `log` field after `Merge_Log`, allowing VictoriaLogs to map it to `_msg`

## Test plan
- [ ] Verify fluent-bit pods become healthy (readiness/liveness probes pass)
- [ ] Check VictoriaLogs no longer shows `missing _msg field` warnings
- [ ] Confirm logs are still ingested and queryable in VictoriaLogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)