### PR TITLE
fix(grafana): correct Pocket-ID OIDC endpoint paths

### DIFF
--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -56,8 +56,8 @@ spec:
         client_secret: $${GF_OIDC_CLIENT_SECRET}
         scopes: openid profile email
         auth_url: https://pid.${DOMAIN}/authorize
-        token_url: https://pid.${CLUSTER_DOMAIN}/oauth2/token
-        api_url: https://pid.${CLUSTER_DOMAIN}/userinfo
+        token_url: https://pid.${CLUSTER_DOMAIN}/api/oidc/token
+        api_url: https://pid.${CLUSTER_DOMAIN}/api/oidc/userinfo
         auto_sign_up: true
         default_role: Admin
 


### PR DESCRIPTION
## Summary
- Fixed Grafana OIDC token and userinfo endpoint paths to match Pocket-ID's actual API
- `token_url`: `/oauth2/token` → `/api/oidc/token`
- `api_url`: `/userinfo` → `/api/oidc/userinfo`

This fixes the "Failed to get token from provider" error after the auth_url fix in #205.

## Test plan
- [ ] Login to Grafana via Pocket-ID SSO — full flow should complete without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)