### PR TITLE
feat(grafana): add OIDC role mapping via Pocket-ID groups

### DIFF
--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -56,8 +56,8 @@ spec:
         client_secret: $${GF_OIDC_CLIENT_SECRET}
         scopes: openid profile email
         auth_url: https://pid.${DOMAIN}/authorize
-        token_url: https://pid.${CLUSTER_DOMAIN}/oauth2/token
-        api_url: https://pid.${CLUSTER_DOMAIN}/userinfo
+        token_url: https://pid.${CLUSTER_DOMAIN}/api/oidc/token
+        api_url: https://pid.${CLUSTER_DOMAIN}/api/oidc/userinfo
         auto_sign_up: true
         default_role: Admin
 

--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -54,12 +54,13 @@ spec:
         name: Pocket ID
         client_id: $${GF_OIDC_CLIENT_ID}
         client_secret: $${GF_OIDC_CLIENT_SECRET}
-        scopes: openid profile email
+        scopes: openid profile email groups
         auth_url: https://pid.${DOMAIN}/authorize
         token_url: https://pid.${CLUSTER_DOMAIN}/api/oidc/token
         api_url: https://pid.${CLUSTER_DOMAIN}/api/oidc/userinfo
         auto_sign_up: true
-        default_role: Admin
+        groups_attribute_path: groups
+        role_attribute_path: contains(groups[*], 'grafana-admin') && 'Admin' || 'Viewer'
 
     # Datasources
     datasources:


### PR DESCRIPTION
## Summary
- Added `groups` to OIDC scopes so Pocket-ID returns group membership
- Added `role_attribute_path` with JMESPath: `grafana-admin` group → Admin, others → Viewer
- Replaced hardcoded `default_role: Admin` with group-based role mapping

## Prerequisites
- Create a `grafana-admin` group in Pocket-ID
- Add your user to the `grafana-admin` group

## Test plan
- [ ] Login to Grafana as a user in `grafana-admin` group — should get Admin role
- [ ] Login as a user NOT in the group — should get Viewer role

🤖 Generated with [Claude Code](https://claude.com/claude-code)