### PR TITLE
fix(observability): correct VictoriaLogs _msg mapping and Grafana log queries

### DIFF
--- a/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
@@ -52,6 +52,6 @@ spec:
             Match       *
             Host        victoria-logs-victoria-logs-single-server.observability.svc.cluster.local
             Port        9428
-            URI         /insert/loki/api/v1/push
+            URI         /insert/loki/api/v1/push?_msg_field=log
             Labels      job=fluent-bit
             Label_Keys  $kubernetes['namespace_name'], $kubernetes['pod_name'], $kubernetes['container_name']

--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -62,6 +62,10 @@ spec:
         groups_attribute_path: groups
         role_attribute_path: contains(groups[*], 'grafana-admin') && 'Admin' || 'Viewer'
 
+    # Grafana plugins
+    plugins:
+      - victoriametrics-logs-datasource
+
     # Datasources
     datasources:
       datasources.yaml:
@@ -74,7 +78,7 @@ spec:
             jsonData:
               timeInterval: "30s"
           - name: VictoriaLogs
-            type: loki
+            type: victoriametrics-logs-datasource
             url: http://victoria-logs-victoria-logs-single-server.observability.svc.cluster.local:9428
             jsonData:
               maxLines: 1000


### PR DESCRIPTION
## Summary
- **fluent-bit**: Add `?_msg_field=log` to the Loki push URI so VictoriaLogs maps the `log` field to `_msg` instead of showing "missing _msg field" for every entry
- **grafana**: Replace `loki` datasource type with `victoriametrics-logs-datasource` plugin — the Loki type queries `/loki/api/v1/query_range` which VictoriaLogs doesn't support

## Test plan
- [ ] Verify new log entries in VictoriaLogs UI show actual message content in `_msg` instead of the "missing _msg field" warning
- [ ] Verify Grafana can query logs via the VictoriaLogs datasource (use `*` in Explore)
- [ ] Confirm existing log labels (namespace, pod, container) still work as filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)