### PR TITLE
fix(fluent-bit): restore Merge_Log and Keep_Log for searchable labels

### DIFF
--- a/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
@@ -44,6 +44,8 @@ spec:
             Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
             Kube_Meta_Cache_TTL 300
+            Merge_Log           On
+            Keep_Log            On
       outputs: |
         [OUTPUT]
             Name        loki


### PR DESCRIPTION
## Summary
- Restore `Merge_Log On` so JSON log fields are parsed into separate searchable labels in VictoriaLogs
- Restore `Keep_Log On` to preserve the original `log` field needed for `_msg_field=log` mapping

## Test plan
- [ ] Verify JSON log fields appear as searchable labels in VictoriaLogs
- [ ] Verify `_msg` field is properly populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)