### PR TITLE
feat(observability): enable Prometheus metrics and add Grafana dashboards

### DIFF
--- a/kubernetes/apps/talos1018/kube-system/reloader/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/kube-system/reloader/app/deployment.yaml
@@ -20,6 +20,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: reloader-reloader
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
     spec:
       containers:
         - image: "ghcr.io/stakater/reloader:v1.4.12"

--- a/kubernetes/apps/talos1018/network/cloudflared/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/network/cloudflared/app/deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: cloudflared
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2000"
     spec:
       containers:
         - name: cloudflared

--- a/kubernetes/apps/talos1018/observability/alertmanager/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/alertmanager/app/helmrelease.yaml
@@ -13,6 +13,9 @@ spec:
         name: prometheus
   interval: 1h0m0s
   values:
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9093"
     resources:
       requests:
         cpu: 25m

--- a/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/fluent-bit/app/helmrelease.yaml
@@ -13,6 +13,10 @@ spec:
         name: fluent
   interval: 1h0m0s
   values:
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "2020"
+      prometheus.io/path: /api/v1/metrics/prometheus
     resources:
       requests:
         cpu: 50m

--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -110,6 +110,58 @@ spec:
           gnetId: 15760
           revision: 36
           datasource: VictoriaMetrics
+        kubernetes-views-namespaces:
+          gnetId: 15758
+          revision: 42
+          datasource: VictoriaMetrics
+        victorialogs-single-node:
+          gnetId: 22084
+          revision: 6
+          datasource: VictoriaMetrics
+        fluent-bit:
+          gnetId: 18855
+          revision: 1
+          datasource: VictoriaMetrics
+        ingress-nginx:
+          gnetId: 9614
+          revision: 1
+          datasource: VictoriaMetrics
+        cert-manager:
+          gnetId: 20842
+          revision: 3
+          datasource: VictoriaMetrics
+        longhorn:
+          gnetId: 16888
+          revision: 9
+          datasource: VictoriaMetrics
+        cilium-agent:
+          gnetId: 16611
+          revision: 1
+          datasource: VictoriaMetrics
+        cilium-hubble:
+          gnetId: 16613
+          revision: 1
+          datasource: VictoriaMetrics
+        n8n-system-health:
+          gnetId: 24474
+          revision: 1
+          datasource: VictoriaMetrics
+        n8n-workflow-analytics:
+          gnetId: 24475
+          revision: 1
+          datasource: VictoriaMetrics
+        cloudflare-tunnels:
+          gnetId: 17457
+          revision: 6
+          datasource: VictoriaMetrics
+        alertmanager:
+          gnetId: 9578
+          revision: 4
+          datasource: VictoriaMetrics
+        vmalert:
+          gnetId: 14950
+          revision: 18
+          datasource: VictoriaMetrics
 
     # Ingress
     ingress:

--- a/kubernetes/apps/talos1018/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-logs/app/helmrelease.yaml
@@ -14,6 +14,9 @@ spec:
   interval: 1h0m0s
   values:
     server:
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9428"
       extraArgs:
         httpListenAddr: "[::]:9428"
         enableTCP6: "true"

--- a/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
@@ -172,6 +172,20 @@ spec:
                     - __meta_kubernetes_service_name
                   action: keep
                   regex: kube-state-metrics
+
+            # Longhorn manager metrics
+            - job_name: longhorn
+              kubernetes_sd_configs:
+                - role: endpoints
+                  namespaces:
+                    names:
+                      - longhorn-system
+              relabel_configs:
+                - source_labels:
+                    - __meta_kubernetes_service_name
+                    - __meta_kubernetes_endpoint_port_name
+                  action: keep
+                  regex: longhorn-backend;manager
     # Standalone charts are used for these — disable the bundled ones
     vmagent:
       enabled: false

--- a/kubernetes/apps/talos1018/observability/vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/vmalert/app/helmrelease.yaml
@@ -14,6 +14,9 @@ spec:
   interval: 1h0m0s
   values:
     server:
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8880"
       extraArgs:
         httpListenAddr: "[::]:8880"
         enableTCP6: "true"

--- a/kubernetes/apps/talos1018/self-hosted/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/n8n/app/helmrelease.yaml
@@ -34,6 +34,8 @@ spec:
               N8N_HOST: &hostName n8n.${CLUSTER_DOMAIN}
               N8N_LOG_LEVEL: info
               N8N_LOG_OUTPUT: console
+              N8N_METRICS: true
+              N8N_METRICS_PREFIX: n8n_
               N8N_ENCRYPTION_KEY:
                 valueFrom:
                   secretKeyRef:
@@ -46,6 +48,10 @@ spec:
               limits:
                 memory: 2Gi
         pod:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "8080"
+            prometheus.io/path: /metrics
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000

--- a/kubernetes/infrastructure/talos1018/core/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cert-manager/app/helmrelease.yaml
@@ -18,3 +18,7 @@ spec:
   values:
     crds:
       enabled: true
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9402"
+      prometheus.io/path: /metrics

--- a/kubernetes/infrastructure/talos1018/core/cilium/app/values.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cilium/app/values.yaml
@@ -52,6 +52,10 @@ enableIPv4Masquerade: true
 # bpf:
 #   masquerade: true
 
+# Prometheus metrics for Cilium agent
+prometheus:
+  enabled: true
+
 # Hubble observability
 hubble:
   enabled: true

--- a/kubernetes/infrastructure/talos1018/core/ingress-nginx/app/helmrelease.yaml
+++ b/kubernetes/infrastructure/talos1018/core/ingress-nginx/app/helmrelease.yaml
@@ -16,6 +16,13 @@ spec:
   interval: 1m0s
   values:
     controller:
+      metrics:
+        enabled: true
+        port: 10254
+        portName: metrics
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "10254"
       service:
         labels:
           service.kubernetes.io/topology: external


### PR DESCRIPTION
## Summary

- Enable Prometheus scrape annotations on 10 apps: fluent-bit, victoria-logs, ingress-nginx, cert-manager, cilium, n8n, cloudflared, reloader, vmalert, alertmanager
- Add dedicated VictoriaMetrics scrape job for Longhorn (service-level metrics)
- Add 13 new Grafana community dashboards (16 total, was 3)

### Metrics enabled via `prometheus.io/scrape` pod annotations
| App | Port | Notes |
|-----|------|-------|
| fluent-bit | 2020 | Pipeline metrics |
| victoria-logs | 9428 | Log ingestion metrics |
| ingress-nginx | 10254 | Controller + request metrics |
| cert-manager | 9402 | Certificate lifecycle metrics |
| cilium | agent default | `prometheus.enabled: true` |
| n8n | 8080 | `N8N_METRICS=true` env var |
| cloudflared | 2000 | Already had `TUNNEL_METRICS` configured |
| reloader | 9090 | Already exposed `/metrics` as readiness probe |
| vmalert | 8880 | Alert rule evaluation metrics |
| alertmanager | 9093 | Alert routing metrics |
| longhorn | dedicated scrape job | Targets `longhorn-backend;manager` endpoint |

### Grafana dashboards added
| Dashboard | gnetId | Revision |
|-----------|--------|----------|
| Kubernetes Views - Namespaces | 15758 | 42 |
| VictoriaLogs Single Node | 22084 | 6 |
| Fluent Bit | 18855 | 1 |
| Ingress NGINX | 9614 | 1 |
| cert-manager | 20842 | 3 |
| Longhorn | 16888 | 9 |
| Cilium Agent | 16611 | 1 |
| Cilium Hubble | 16613 | 1 |
| n8n System Health | 24474 | 1 |
| n8n Workflow Analytics | 24475 | 1 |
| Cloudflare Tunnels | 17457 | 6 |
| Alertmanager | 9578 | 4 |
| VMAlert | 14950 | 18 |

## Test plan
- [ ] Verify Flux reconciles all changed HelmReleases without errors
- [ ] Confirm VictoriaMetrics targets page shows new scrape targets
- [ ] Check each Grafana dashboard loads and displays data
- [ ] Verify no pod restart loops from annotation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)