### PR TITLE
fix(observability): correct alertmanager ingress class and add Grafana datasource

### DIFF
--- a/kubernetes/apps/talos1018/observability/alertmanager/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/alertmanager/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       enabled: false
     ingress:
       enabled: true
-      ingressClassName: nginx
+      className: nginx
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         gethomepage.dev/enabled: "true"

--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -82,6 +82,11 @@ spec:
             url: http://victoria-logs-victoria-logs-single-server.observability.svc.cluster.local:9428
             jsonData:
               maxLines: 1000
+          - name: Alertmanager
+            type: alertmanager
+            url: http://alertmanager.observability.svc.cluster.local:9093
+            jsonData:
+              implementation: prometheus
 
     # Dashboards
     dashboardProviders:


### PR DESCRIPTION
## Summary
- Fix alertmanager ingress showing `<none>` for class by using `className` instead of `ingressClassName` (the prometheus-community/alertmanager chart convention)
- Add Alertmanager as a Grafana datasource (`type: alertmanager`) for unified alerting support

## Test plan
- [ ] Verify alertmanager ingress shows `nginx` class: `kubectl get ingress -A | grep alertmanager`
- [ ] Verify alertmanager is accessible at `https://alertmanager.1018.murodov.org`
- [ ] Verify Alertmanager datasource appears in Grafana under Configuration > Data Sources
- [ ] Verify Grafana alerting can connect to Alertmanager

🤖 Generated with [Claude Code](https://claude.com/claude-code)