### PR TITLE
fix(observability): correct VictoriaLogs dashboard datasource

### DIFF
--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -122,7 +122,7 @@ spec:
         victorialogs-single-node:
           gnetId: 22084
           revision: 6
-          datasource: VictoriaMetrics
+          datasource: VictoriaLogs
         fluent-bit:
           gnetId: 18855
           revision: 1


### PR DESCRIPTION
## Summary

- Fix VictoriaLogs single-node dashboard (gnetId 22084) datasource from `VictoriaMetrics` to `VictoriaLogs`
- Dashboard 22084 queries log data and requires the `victoriametrics-logs-datasource` plugin, not the Prometheus-type metrics datasource

## Test plan

- [ ] Verify Grafana reconciles successfully after merge
- [ ] Confirm the VictoriaLogs dashboard loads and displays log data correctly