### PR TITLE
fix(observability): fix broken Grafana dashboards and IPv6 pod scraping

### DIFF
--- a/kubernetes/apps/talos1018/network/cloudflared/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/network/cloudflared/app/deployment.yaml
@@ -40,6 +40,10 @@ spec:
                 secretKeyRef:
                   name: cloudflared-secret
                   key: TUNNEL_TOKEN
+          ports:
+            - name: metrics
+              containerPort: 2000
+              protocol: TCP
           resources:
             limits:
               cpu: "0.05"

--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -128,8 +128,8 @@ spec:
           revision: 1
           datasource: VictoriaMetrics
         ingress-nginx:
-          gnetId: 9614
-          revision: 1
+          gnetId: 14314
+          revision: 2
           datasource: VictoriaMetrics
         cert-manager:
           gnetId: 20842
@@ -137,7 +137,7 @@ spec:
           datasource: VictoriaMetrics
         longhorn:
           gnetId: 16888
-          revision: 9
+          revision: 11
           datasource: VictoriaMetrics
         cilium-agent:
           gnetId: 16611
@@ -149,10 +149,6 @@ spec:
           datasource: VictoriaMetrics
         n8n-system-health:
           gnetId: 24474
-          revision: 1
-          datasource: VictoriaMetrics
-        n8n-workflow-analytics:
-          gnetId: 24475
           revision: 1
           datasource: VictoriaMetrics
         cloudflare-tunnels:

--- a/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
@@ -133,13 +133,30 @@ spec:
                   target_label: __metrics_path__
                   regex: (.+)
                   replacement: $1
+                # IPv4: 10.0.0.1(:port)?;annotation → 10.0.0.1:annotation
                 - source_labels:
                     - __address__
                     - __meta_kubernetes_pod_annotation_prometheus_io_port
                   action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  regex: (\d+\.\d+\.\d+\.\d+)(?::\d+)?;(\d+)
                   target_label: __address__
                   replacement: $1:$2
+                # IPv6 with brackets: [fd00::1](:port)?;annotation → [fd00::1]:annotation
+                - source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  action: replace
+                  regex: (\[.+?\])(?::\d+)?;(\d+)
+                  target_label: __address__
+                  replacement: $1:$2
+                # Bare IPv6: fd00::1;annotation → [fd00::1]:annotation
+                - source_labels:
+                    - __address__
+                    - __meta_kubernetes_pod_annotation_prometheus_io_port
+                  action: replace
+                  regex: ([0-9a-fA-F][0-9a-fA-F:]+);(\d+)
+                  target_label: __address__
+                  replacement: "[$1]:$2"
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
                 - source_labels:


### PR DESCRIPTION
## Summary

- **Fix IPv6 pod scraping**: The `kubernetes-pods` scrape job regex `([^:]+)` cannot parse IPv6 pod addresses, breaking all annotation-based metric collection in the dual-stack cluster. Replaced with three rules handling IPv4, bracketed IPv6, and bare IPv6 addresses.
- **Replace outdated nginx ingress dashboard** 9614 (2018) with NextGen 14314 rev 2 (1.6M+ downloads, actively maintained)
- **Update Longhorn dashboard** to rev 11 (fixes `${datasource}` template variable not mapping to VictoriaMetrics)
- **Remove n8n-workflow-analytics dashboard** (requires PostgreSQL datasource but n8n uses SQLite)
- **Add containerPort to cloudflared** deployment for proper Kubernetes service discovery of metrics endpoint

## Test plan

- [ ] Verify VictoriaMetrics targets page shows cloudflared and n8n pods as active scrape targets
- [ ] Confirm `cloudflared_*` and `n8n_*` metrics appear in VictoriaMetrics
- [ ] Check nginx ingress, Longhorn, n8n System Health, and Cloudflare Tunnel Grafana dashboards show data