### PR TITLE
fix(paperless): escape TIKA_VERSION to prevent Flux substitution

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
@@ -157,7 +157,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - "exec java -cp \"/tika-server-standard-${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h :: $0 $@"
+              - "exec java -cp \"/tika-server-standard-$${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h :: $0 $@"
             resources:
               requests:
                 cpu: "0.002"


### PR DESCRIPTION
Flux postBuild substituteFrom was replacing ${TIKA_VERSION} with an empty string, causing the tika container to crash with ClassNotFoundException since the JAR path resolved to /tika-server-standard-.jar instead of the correct path.