### PR TITLE
fix(paperless): increase tika CPU limits for JVM startup

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
@@ -160,10 +160,10 @@ spec:
               - "exec java -cp \"/tika-server-standard-$${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h :: $0 $@"
             resources:
               requests:
-                cpu: "0.002"
-                memory: 200Mi
+                cpu: 50m
+                memory: 256Mi
               limits:
-                cpu: "0.02"
+                cpu: "1"
                 memory: 1Gi
 
     service:


### PR DESCRIPTION
Tika's forked process failed to start within 120s timeout because the CPU limit of 20m was too low for JVM class loading. Increased to 1 core limit with 50m request.