### PR TITLE
fix(paperless): use bracketed IPv6 notation for tika host bind

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
@@ -157,7 +157,7 @@ spec:
             command:
               - /bin/sh
               - -c
-              - "exec java -cp \"/tika-server-standard-$${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h :: $0 $@"
+              - "exec java -cp \"/tika-server-standard-$${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h [::] $0 $@"
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
Tika 3.x URL parser fails on bare `::` with NumberFormatException. Use `[::]` instead which is the correct bracketed IPv6 format.