### PR TITLE
fix(ci): improve Claude Code Review performance

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -18,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write  # Changed from 'read' to 'write' to allow posting review comments
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -32,9 +26,19 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@0ee1beea589a67d33340072691a5d42abec7ae6b # v1
         with:
+          model: claude-sonnet-4-6
+          max_turns: "5"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
-          plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          review_comment_prefix: "**Claude Review:**"
+          prompt: |
+            Review this pull request. Focus on:
+            - YAML syntax and structural correctness
+            - Flux CD Kustomization dependency issues
+            - Secret handling (no unencrypted secrets, proper .sops.yaml naming)
+            - Consistency with existing patterns in the repo (check CLAUDE.md)
+            - Potential breaking changes to the GitOps pipeline
+
+            - Documentation accuracy (do code changes conflict with README files, CLAUDE.md, or other docs?)
+            - If docs are changed, verify they match the actual code/config state
+
+            Be concise. Only comment on actual issues, not style preferences.


### PR DESCRIPTION
## Summary
- Remove plugin marketplace approach that clones the entire `anthropics/claude-code.git` repo on every run
- Switch model from Opus to Sonnet for faster reviews
- Cap `max_turns` to 5 to prevent excessive iteration
- Use a direct, repo-tailored review prompt covering YAML correctness, Flux dependencies, secret handling, and doc/code consistency

## Test plan
- [ ] Open a test PR and verify the review completes faster
- [ ] Confirm review comments are still relevant and useful

🤖 Generated with [Claude Code](https://claude.com/claude-code)