### PR TITLE
fix(ci): use valid inputs for Claude Code Review action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,10 +26,8 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@0ee1beea589a67d33340072691a5d42abec7ae6b # v1
         with:
-          model: claude-sonnet-4-6
-          max_turns: "5"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          review_comment_prefix: "**Claude Review:**"
+          claude_args: "--model claude-sonnet-4-6 --max-turns 5"
           prompt: |
             Review this pull request. Focus on:
             - YAML syntax and structural correctness


### PR DESCRIPTION
## Summary
- Move `model` and `max_turns` from invalid action inputs to `claude_args` where they are properly passed to Claude CLI
- Remove `review_comment_prefix` which is also not a valid input

The previous PR (#327) used `model`, `max_turns`, and `review_comment_prefix` as direct inputs, but these are not supported by `claude-code-action`. The action warned about unexpected inputs and silently ignored them.

## Test plan
- [ ] Verify no "Unexpected input" warnings in CI logs
- [ ] Confirm Claude uses Sonnet model (check `init` log for `claude-sonnet-4-6`)
- [ ] Verify review comments are posted on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)