### PR TITLE
fix(ci): fix Claude review max-turns and tool permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,10 @@ jobs:
         uses: anthropics/claude-code-action@0ee1beea589a67d33340072691a5d42abec7ae6b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--model claude-sonnet-4-6 --max-turns 5"
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 10
+            --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*)"
           prompt: |
             Review this pull request. Focus on:
             - YAML syntax and structural correctness


### PR DESCRIPTION
## Summary
- Increase `--max-turns` from 5 to 10 — Claude was hitting the limit before completing reviews (`error_max_turns`)
- Pre-approve read-only tools (`Read`, `Glob`, `Grep`, `gh`/`git` commands) via `--allowedTools` to eliminate permission denials that wasted turns

## Test plan
- [ ] Verify no `error_max_turns` in CI logs
- [ ] Verify `permission_denials_count: 0`
- [ ] Confirm review comments are posted on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)