### PR TITLE
feat(network): deploy Gateway and migrate podinfo to Gateway API

### DIFF
--- a/kubernetes/apps/talos1018/network/gateway-api/config/gateway.yaml
+++ b/kubernetes/apps/talos1018/network/gateway-api/config/gateway.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main-gateway
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    io.cilium/lb-ipam-ips: "${IPV6_PREFIX_GUA}:2000:0:6:16,10.18.6.16"
+  labels:
+    service.kubernetes.io/topology: external
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: gateway-tls
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/apps/talos1018/network/gateway-api/config/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/gateway-api/config/kustomization.yaml
@@ -2,9 +2,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: podinfo
 resources:
-  - namespace.yaml
-  - helmrepository.yaml
-  - helmrelease.yaml
-  - httproute.yaml
+  - gateway.yaml

--- a/kubernetes/apps/talos1018/network/gateway-api/ks.yaml
+++ b/kubernetes/apps/talos1018/network/gateway-api/ks.yaml
@@ -21,3 +21,28 @@ spec:
     substituteFrom:
       - kind: Secret
         name: cluster-secrets
+---
+# Gateway API - Config (Gateway resource)
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gateway-api-config
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: gateway-api-app
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: "./kubernetes/apps/talos1018/network/gateway-api/config"
+  targetNamespace: network
+  prune: true
+  wait: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets

--- a/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
@@ -28,21 +28,4 @@ spec:
         memory: 64Mi
 
     ingress:
-      enabled: true
-      className: nginx
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        gethomepage.dev/enabled: "true"
-        gethomepage.dev/group: Infra
-        gethomepage.dev/icon: sh-podinfo.svg
-        gethomepage.dev/name: Podinfo
-        gethomepage.dev/app: podinfo
-      hosts:
-        - host: podinfo.${CLUSTER_DOMAIN}
-          paths:
-            - path: /
-              pathType: Prefix
-      tls:
-        - secretName: podinfo-tls
-          hosts:
-            - podinfo.${CLUSTER_DOMAIN}
+      enabled: false

--- a/kubernetes/apps/talos1018/podinfo/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/podinfo/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: podinfo
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Infra
+    gethomepage.dev/icon: sh-podinfo.svg
+    gethomepage.dev/name: Podinfo
+    gethomepage.dev/app: podinfo
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "podinfo.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: podinfo
+          port: 9898

--- a/kubernetes/infrastructure/talos1018/core/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cert-manager/app/helmrelease.yaml
@@ -18,3 +18,4 @@ spec:
   values:
     crds:
       enabled: true
+    featureGates: "ExperimentalGatewayAPISupport=true"

--- a/kubernetes/infrastructure/talos1018/core/cert-manager/ks.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cert-manager/ks.yaml
@@ -7,6 +7,8 @@ metadata:
   name: infra-cert-manager-app
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: gateway-api-app
   interval: 1h
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/infrastructure/talos1018/core/cilium/app/values.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cilium/app/values.yaml
@@ -7,6 +7,10 @@ l2announcements:
 
 kubeProxyReplacement: false
 
+# Gateway API support
+gatewayAPI:
+  enabled: true
+
 securityContext:
   capabilities:
     ciliumAgent:

--- a/kubernetes/infrastructure/talos1018/core/cilium/ks.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cilium/ks.yaml
@@ -7,6 +7,8 @@ metadata:
   name: infra-cilium-app
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: gateway-api-app
   interval: 1h
   retryInterval: 1m
   timeout: 5m


### PR DESCRIPTION
## Summary
- Enable Cilium `gatewayAPI` and cert-manager `ExperimentalGatewayAPISupport`
- Add `dependsOn: gateway-api-app` to Cilium/cert-manager ks.yaml for cluster rebuild safety
- Deploy `main-gateway` in network namespace (`10.18.6.16` / `${IPV6_PREFIX_GUA}:2000:0:6:16`)
- Migrate podinfo from ingress-nginx Ingress to Gateway API HTTPRoute

Phase 1 of ingress-nginx → Gateway API migration. Validates the full chain: CRDs → Cilium GW controller → Gateway → HTTPRoute → cert-manager TLS.

## Test plan
- [ ] Cilium pods restart cleanly with `gatewayAPI.enabled`
- [ ] cert-manager picks up gateway-shim without crash-looping
- [ ] `kubectl get gateway main-gateway -n network` shows `Accepted: True`, `Programmed: True`
- [ ] Gateway service gets correct IPs (`10.18.6.16` + IPv6)
- [ ] `curl https://podinfo.${CLUSTER_DOMAIN}` via Gateway IP works (v4 + v6)
- [ ] TLS cert issued automatically by cert-manager
- [ ] Update DNS for `podinfo.${CLUSTER_DOMAIN}` to `10.18.6.16`