### PR TITLE
feat(cilium): enable kube-proxy replacement

### DIFF
--- a/kubernetes/infrastructure/talos1018/core/cilium/app/values.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cilium/app/values.yaml
@@ -5,7 +5,7 @@ ipam:
 l2announcements:
   enabled: true
 
-kubeProxyReplacement: false
+kubeProxyReplacement: true
 
 # Gateway API support
 gatewayAPI:

--- a/talos/talos1018/talconfig.yaml
+++ b/talos/talos1018/talconfig.yaml
@@ -19,6 +19,10 @@ clusterSvcNets:
 cniConfig:
   name: none
 
+# Disable kube-proxy (Cilium kube-proxy replacement)
+proxy:
+  disabled: true
+
 additionalApiServerCertSans:
   - ::1
   - fd00:1018:0:5:10:18:6:91


### PR DESCRIPTION
## Summary
- Disable kube-proxy in Talos config (`proxy.disabled: true`)
- Set Cilium `kubeProxyReplacement: true`
- Required for Cilium Gateway API controller (currently warns and refuses to start)

## Apply order
1. Merge this PR
2. Apply Talos config to each node (rolling):
   ```bash
   cd talos/talos1018
   talhelper genconfig
   talosctl apply-config -n fd00:1018:0:5:10:18:6:91 --file clusterconfig/talos1018-talos-1018-1.yaml
   talosctl apply-config -n fd00:1018:0:5:10:18:6:92 --file clusterconfig/talos1018-talos-1018-2.yaml
   talosctl apply-config -n fd00:1018:0:5:10:18:6:93 --file clusterconfig/talos1018-talos-1018-3.yaml
   ```
3. Flux reconciles Cilium with `kubeProxyReplacement: true`
4. Restart Cilium: `kubectl rollout restart ds/cilium -n kube-system && kubectl rollout restart deploy/cilium-operator -n kube-system`
5. Verify: `kubectl exec -n kube-system ds/cilium -- cilium status | grep KubeProxyReplacement`

## Test plan
- [ ] All nodes accept new config without reboot
- [ ] kube-proxy pods stop after Talos config applied
- [ ] Cilium takes over service routing (all existing services remain accessible)
- [ ] `kubectl get gateway main-gateway -n network` shows `Programmed: True`