### PR TITLE
fix(network): use experimental Gateway API CRDs

### DIFF
--- a/kubernetes/apps/talos1018/network/gateway-api/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/gateway-api/app/kustomization.yaml
@@ -4,4 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/experimental-install.yaml


### PR DESCRIPTION
## Summary
Cilium 1.19 requires `TLSRoute` CRD (`gateway.networking.k8s.io/v1alpha2`) which is only available in the experimental channel. The operator crash-loops with:

```
no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1alpha2"
```

Switch from `standard-install.yaml` to `experimental-install.yaml`.

After merge, restart Cilium operator: `kubectl rollout restart deployment/cilium-operator -n kube-system`