### PR TITLE
fix(network): use spec.infrastructure for Gateway service config

### DIFF
--- a/kubernetes/apps/talos1018/network/gateway-api/config/gateway.yaml
+++ b/kubernetes/apps/talos1018/network/gateway-api/config/gateway.yaml
@@ -5,11 +5,13 @@ metadata:
   name: main-gateway
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    io.cilium/lb-ipam-ips: "${IPV6_PREFIX_GUA}:2000:0:6:16,10.18.6.16"
-  labels:
-    service.kubernetes.io/topology: external
 spec:
   gatewayClassName: cilium
+  infrastructure:
+    annotations:
+      io.cilium/lb-ipam-ips: "${IPV6_PREFIX_GUA}:2000:0:6:16,10.18.6.16"
+    labels:
+      service.kubernetes.io/topology: external
   listeners:
     - name: http
       protocol: HTTP


### PR DESCRIPTION
## Summary
Move `io.cilium/lb-ipam-ips` and `service.kubernetes.io/topology` from Gateway metadata to `spec.infrastructure` so Cilium propagates them to the auto-created LoadBalancer service.

Without this, the Gateway service gets no external IP (stuck at `<pending>`).