### PR TITLE
fix(network): add hostname to Gateway HTTPS listeners for TLS

### DIFF
--- a/kubernetes/apps/talos1018/network/gateway-api/config/gateway.yaml
+++ b/kubernetes/apps/talos1018/network/gateway-api/config/gateway.yaml
@@ -19,13 +19,25 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: https
+    - name: https-internal
+      hostname: "*.${CLUSTER_DOMAIN}"
       protocol: HTTPS
       port: 443
       tls:
         mode: Terminate
         certificateRefs:
-          - name: gateway-tls
+          - name: gateway-internal-tls
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: https-external
+      hostname: "*.${DOMAIN}"
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: gateway-external-tls
       allowedRoutes:
         namespaces:
           from: All


### PR DESCRIPTION
## Summary
cert-manager gateway-shim needs a hostname on HTTPS listeners to issue certificates. Without it, the `gateway-tls` secret is never created and HTTPS fails with connection reset.

Add two HTTPS listeners with wildcard hostnames:
- `https-internal`: `*.${CLUSTER_DOMAIN}` — covers all internal apps
- `https-external`: `*.${DOMAIN}` — covers external-facing apps

cert-manager will create wildcard certificates for each via Cloudflare DNS01.