### PR TITLE
fix(cert-manager): enable Gateway API via config

### DIFF
--- a/kubernetes/infrastructure/talos1018/core/cert-manager/app/helmrelease.yaml
+++ b/kubernetes/infrastructure/talos1018/core/cert-manager/app/helmrelease.yaml
@@ -18,4 +18,5 @@ spec:
   values:
     crds:
       enabled: true
-    featureGates: "ExperimentalGatewayAPISupport=true"
+    config:
+      enableGatewayAPI: true


### PR DESCRIPTION
## Summary
- Replace deprecated `featureGates: ExperimentalGatewayAPISupport=true` with `config.enableGatewayAPI: true`
- This creates the missing `cert-manager-controller-gateway-shim` ClusterRole with Gateway API RBAC
- Without RBAC, cert-manager skips the gateway-shim controller and never creates certificates for Gateway listeners

## Test plan
- [ ] cert-manager pod restarts with gateway-shim controller enabled (no longer "skipping disabled controller")
- [ ] Certificates `gateway-internal-tls` and `gateway-external-tls` created in `network` namespace
- [ ] `https://podinfo.1018.murodov.org` returns valid TLS