### PR TITLE
feat(homepage): enable Gateway API HTTPRoute discovery

### DIFF
--- a/kubernetes/apps/talos1018/homepage/app/clusterrole.yaml
+++ b/kubernetes/apps/talos1018/homepage/app/clusterrole.yaml
@@ -25,6 +25,14 @@ rules:
       - get
       - list
   - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - httproutes
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - metrics.k8s.io
     resources:
       - nodes

--- a/kubernetes/apps/talos1018/homepage/app/configmap.yaml
+++ b/kubernetes/apps/talos1018/homepage/app/configmap.yaml
@@ -21,6 +21,7 @@ data:
   kubernetes.yaml: |
     mode: cluster
     ingress: true
+    gateway: true
   services.yaml: |
     - Apps:
       - Printer:


### PR DESCRIPTION
## Summary
- Add `gateway: true` to Homepage kubernetes.yaml config
- Add RBAC for `gateway.networking.k8s.io` (gateways, httproutes) to ClusterRole
- Homepage will now discover services via `gethomepage.dev/*` annotations on HTTPRoutes

## Test plan
- [ ] Homepage pod restarts successfully
- [ ] Podinfo appears on the dashboard (discovered via its HTTPRoute annotations)