### PR TITLE
fix(apps): bind bricktracker and esphome to IPv6

### DIFF
--- a/kubernetes/apps/talos1018/bricktracker/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/bricktracker/app/deployment.yaml
@@ -28,6 +28,9 @@ spec:
             - name: http
               containerPort: 3333
               protocol: TCP
+          env:
+            - name: BK_HOST
+              value: "::"
           envFrom:
             - configMapRef:
                 name: bricktracker-config

--- a/kubernetes/apps/talos1018/home-automation/esphome/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/home-automation/esphome/app/deployment.yaml
@@ -22,6 +22,8 @@ spec:
         - name: esphome
           image: "ghcr.io/esphome/esphome:2026.3.0"
           imagePullPolicy: Always
+          command: ["esphome"]
+          args: ["dashboard", "/config", "--address", "::"]
           ports:
             - name: http
               containerPort: 6052


### PR DESCRIPTION
## Summary
- BrickTracker: add `BK_HOST="::"` env var so gunicorn binds dual-stack
- ESPHome: add `--address ::` CLI flag so tornado binds dual-stack
- Both apps defaulted to `0.0.0.0` (IPv4 only) causing intermittent 503s when envoy routed to the IPv6 endpoint

## Test plan
- [ ] Both pods restart and listen on `[::]`
- [ ] `curl` to both apps returns consistent 200/302 (no more intermittent 503s)