### PR TITLE
fix(esphome): switch service to IPv6 SingleStack

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/esphome/app/service.yaml
+++ b/kubernetes/apps/talos1018/home-automation/esphome/app/service.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     app.kubernetes.io/name: esphome
 spec:
-  ipFamilyPolicy: PreferDualStack
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv6
   ports:
     - port: 6052
       targetPort: 6052


### PR DESCRIPTION
## Summary
- Switch esphome service from PreferDualStack to SingleStack IPv6
- ESPHome with `--address ::` only listens on IPv6, so the IPv4 endpoint is dead
- Envoy was hitting the dead IPv4 endpoint ~50% of the time causing intermittent 503s

## Test plan
- [ ] esphome consistently returns 302 (no more 503s)