### PR TITLE
fix(adsb): move hostnames to *.CLUSTER_DOMAIN for TLS

### DIFF
--- a/kubernetes/apps/talos1018/adsb/app/flightradar24-httproute.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/flightradar24-httproute.yaml
@@ -14,7 +14,7 @@ spec:
     - name: main-gateway
       namespace: network
   hostnames:
-    - "fr24.adsb.${CLUSTER_DOMAIN}"
+    - "fr24.${CLUSTER_DOMAIN}"
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/talos1018/adsb/app/piaware-httproute.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/piaware-httproute.yaml
@@ -14,7 +14,7 @@ spec:
     - name: main-gateway
       namespace: network
   hostnames:
-    - "piaware.adsb.${CLUSTER_DOMAIN}"
+    - "piaware.${CLUSTER_DOMAIN}"
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/talos1018/adsb/app/planefinder-httproute.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/planefinder-httproute.yaml
@@ -14,7 +14,7 @@ spec:
     - name: main-gateway
       namespace: network
   hostnames:
-    - "planefinder.adsb.${CLUSTER_DOMAIN}"
+    - "planefinder.${CLUSTER_DOMAIN}"
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/talos1018/adsb/app/planefinder-service.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/planefinder-service.yaml
@@ -6,6 +6,9 @@ metadata:
   name: planefinder
   namespace: adsb
 spec:
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
   selector:
     app.kubernetes.io/name: planefinder
   ports:


### PR DESCRIPTION
## Summary
- Change ADSB hostnames from `*.adsb.1018.murodov.org` to `*.1018.murodov.org`
- Wildcard TLS cert only covers `*.1018.murodov.org`, not sub-subdomains
- `fr24.adsb` → `fr24`, `piaware.adsb` → `piaware`, `planefinder.adsb` → `planefinder`

## DNS records to update
- `fr24.1018.murodov.org` (replace `fr24.adsb.1018.murodov.org`)
- `piaware.1018.murodov.org` (replace `piaware.adsb.1018.murodov.org`)
- `planefinder.1018.murodov.org` (replace `planefinder.adsb.1018.murodov.org`)

## Test plan
- [ ] HTTPS works for all 3 ADSB apps on new hostnames