### PR TITLE
fix(changedetection): escape Homepage widget key annotation for Helm

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/changedetection/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/changedetection/app/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
           gethomepage.dev/description: Web page change detection
           gethomepage.dev/widget.type: changedetectionio
           gethomepage.dev/widget.url: http://changedetection-http.self-hosted.svc.cluster.local:5000
-          gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_CHANGEDETECTION_APIKEY}}"
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_CHANGEDETECTION_APIKEY}}" }}'
         enabled: true
         hosts:
           - host: changedetection.${CLUSTER_DOMAIN}


### PR DESCRIPTION
## Summary
- The `gethomepage.dev/widget.key` annotation value `{{HOMEPAGE_VAR_CHANGEDETECTION_APIKEY}}` was being parsed as a Go template expression by Helm, causing the HelmRelease to fail with `function "HOMEPAGE_VAR_CHANGEDETECTION_APIKEY" not defined`
- Wrapped the value in Helm template escaping (`'{{ "{{...}}" }}'`) so the literal double-curly-brace string is passed through to the ingress annotation

## Test plan
- [x] `./scripts/validate.sh` passes
- [ ] Flux reconciles the HelmRelease successfully
- [ ] Homepage widget displays changedetection data

🤖 Generated with [Claude Code](https://claude.com/claude-code)