### PR TITLE
fix(paperless): escape Homepage widget key annotation for Helm

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
@@ -220,7 +220,7 @@ spec:
           gethomepage.dev/description: Document management system
           gethomepage.dev/widget.type: paperlessngx
           gethomepage.dev/widget.url: http://paperless-http.self-hosted.svc.cluster.local:8000
-          gethomepage.dev/widget.key: "{{HOMEPAGE_VAR_PAPERLESS_APIKEY}}"
+          gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_PAPERLESS_APIKEY}}" }}'
         enabled: true
         hosts:
           - host: paperless.${CLUSTER_DOMAIN}


### PR DESCRIPTION
## Summary
- Same issue as #347 — `{{HOMEPAGE_VAR_PAPERLESS_APIKEY}}` in the `gethomepage.dev/widget.key` ingress annotation was parsed as Go template syntax by Helm, failing the HelmRelease
- Escaped with `'{{ "{{...}}" }}'` so Helm outputs the literal value

## Test plan
- [x] `./scripts/validate.sh` passes
- [ ] Flux reconciles the HelmRelease successfully
- [ ] Homepage widget displays paperless data

🤖 Generated with [Claude Code](https://claude.com/claude-code)