### PR TITLE
fix(matter-server): add NET_RAW capability for Multus network access

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/helmrelease.yaml
@@ -45,6 +45,8 @@ spec:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
               capabilities:
+                add:
+                  - NET_RAW
                 drop:
                   - ALL
               seccompProfile:


### PR DESCRIPTION
## Summary
- Add `NET_RAW` capability to matter-server container to restore connectivity over Multus macvlan interfaces (VLAN 2/3)
- After Talos 1.12.2 → 1.12.6 upgrade, the newer containerd/runc enforces `capabilities: drop: [ALL]` more strictly, breaking ICMP and mDNS/multicast needed for Matter device discovery
- Home-assistant is unaffected as it runs with default capabilities

## Test plan
- [ ] Verify matter-server pod can ping Thread border router: `kubectl exec -n home-automation matter-server-0 -- ping -c 1 fd4d:*`
- [ ] Verify Matter devices are discoverable and connectable from matter-server