### PR TITLE
feat(network): Phase 4 - migrate Helm-managed apps to Gateway API

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/ha/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/ha/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
 
     ingress:
       app:
-        enabled: true
+        enabled: false
         className: nginx
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/ha/httproute.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/ha/httproute.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: home-assistant
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Smart Home
+    gethomepage.dev/icon: home-assistant.svg
+    gethomepage.dev/name: Home Assistant
+    gethomepage.dev/app: home-assistant
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "hass.${CLUSTER_DOMAIN}"
+    - "hass.${DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: home-assistant
+          port: 8123

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/ha/kustomization.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/ha/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/media/music-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/media/music-assistant/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
 
     ingress:
       app:
-        enabled: true
+        enabled: false
         className: nginx
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt

--- a/kubernetes/apps/talos1018/media/music-assistant/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/media/music-assistant/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: music-assistant
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: sh-music-assistant.svg
+    gethomepage.dev/name: Music Assistant
+    gethomepage.dev/app: music-assistant
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "mass.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: music-assistant-app
+          port: 8095

--- a/kubernetes/apps/talos1018/media/music-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/media/music-assistant/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -169,7 +169,7 @@ spec:
 
     # Ingress
     ingress:
-      enabled: true
+      enabled: false
       ingressClassName: nginx
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt

--- a/kubernetes/apps/talos1018/observability/grafana/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: sh-grafana.svg
+    gethomepage.dev/name: Grafana
+    gethomepage.dev/app: grafana
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "grafana.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: grafana
+          port: 80

--- a/kubernetes/apps/talos1018/observability/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./pvc.yaml
   - ./grafana-secret.sops.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/security/pocket-id/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           gethomepage.dev/icon: sh-pocket-id.svg
           gethomepage.dev/name: Pocket ID
           gethomepage.dev/app: pocket-id
-        enabled: true
+        enabled: false
         hosts:
           - host: pid.${DOMAIN}
             paths:

--- a/kubernetes/apps/talos1018/security/pocket-id/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/security/pocket-id/app/httproute.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: pocket-id
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/description: Identity provider
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: sh-pocket-id.svg
+    gethomepage.dev/name: Pocket ID
+    gethomepage.dev/app: pocket-id
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "pid.${DOMAIN}"
+    - "pid.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: pocket-id
+          port: 1411

--- a/kubernetes/apps/talos1018/security/pocket-id/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/security/pocket-id/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./pocket-id-secret.sops.yaml
   - ./oci-repository.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/self-hosted/changedetection/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/changedetection/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
           gethomepage.dev/widget.type: changedetectionio
           gethomepage.dev/widget.url: http://changedetection-http.self-hosted.svc.cluster.local:5000
           gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_CHANGEDETECTION_APIKEY}}" }}'
-        enabled: true
+        enabled: false
         hosts:
           - host: changedetection.${CLUSTER_DOMAIN}
             paths:

--- a/kubernetes/apps/talos1018/self-hosted/changedetection/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/changedetection/app/httproute.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: changedetection
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: sh-changedetection.svg
+    gethomepage.dev/name: changedetection
+    gethomepage.dev/app: changedetection
+    gethomepage.dev/description: Web page change detection
+    gethomepage.dev/widget.type: changedetectionio
+    gethomepage.dev/widget.url: http://changedetection.self-hosted.svc.cluster.local:5000
+    gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_CHANGEDETECTION_APIKEY}}" }}'
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "changedetection.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: changedetection
+          port: 5000

--- a/kubernetes/apps/talos1018/self-hosted/changedetection/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/changedetection/app/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: self-hosted
 resources:
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/self-hosted/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/n8n/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
           gethomepage.dev/name: n8n
           gethomepage.dev/app: n8n
           gethomepage.dev/description: Workflow automation
-        enabled: true
+        enabled: false
         hosts:
           - host: *hostName
             paths:

--- a/kubernetes/apps/talos1018/self-hosted/n8n/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/n8n/app/httproute.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: n8n
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: sh-n8n.svg
+    gethomepage.dev/name: n8n
+    gethomepage.dev/app: n8n
+    gethomepage.dev/description: Workflow automation
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "n8n.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: n8n
+          port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: n8n-webhook
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "n8n-webhook.${DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: n8n
+          port: 8080

--- a/kubernetes/apps/talos1018/self-hosted/n8n/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/n8n/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./pvc.yaml
   - ./n8n-secret.sops.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/helmrelease.yaml
@@ -221,7 +221,7 @@ spec:
           gethomepage.dev/widget.type: paperlessngx
           gethomepage.dev/widget.url: http://paperless-http.self-hosted.svc.cluster.local:8000
           gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_PAPERLESS_APIKEY}}" }}'
-        enabled: true
+        enabled: false
         hosts:
           - host: paperless.${CLUSTER_DOMAIN}
             paths:

--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/httproute.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: paperless
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Apps
+    gethomepage.dev/icon: sh-paperless-ngx.svg
+    gethomepage.dev/name: Paperless-ngx
+    gethomepage.dev/app: paperless
+    gethomepage.dev/description: Document management system
+    gethomepage.dev/widget.type: paperlessngx
+    gethomepage.dev/widget.url: http://paperless.self-hosted.svc.cluster.local:8000
+    gethomepage.dev/widget.key: '{{ "{{HOMEPAGE_VAR_PAPERLESS_APIKEY}}" }}'
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "paperless.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: paperless
+          port: 8000

--- a/kubernetes/apps/talos1018/self-hosted/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/paperless/app/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./pvc.yaml
   - ./paperless-secret.sops.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./backup-cronjob.yaml


### PR DESCRIPTION
## Summary
- Disable nginx ingress for 7 Helm-managed apps: paperless, changedetection, music-assistant, grafana, n8n, pocket-id, home-assistant
- Create standalone HTTPRoute manifests with `gethomepage.dev/*` annotations for Homepage discovery
- n8n gets two HTTPRoutes: `n8n.${CLUSTER_DOMAIN}` (main UI) and `n8n-webhook.${DOMAIN}` (webhooks)
- pocket-id and home-assistant cover both internal (`${CLUSTER_DOMAIN}`) and external (`${DOMAIN}`) hosts

## Test plan
- [ ] All 7 apps accessible via HTTPS on new Gateway IP
- [ ] Homepage shows all 7 services via HTTPRoute annotation discovery
- [x] paperless and changedetection widgets load correctly
- [ ] n8n webhook URL functional (`n8n-webhook.${DOMAIN}`)
- [x] pocket-id OIDC still works for Grafana and paperless login
- [x] home-assistant accessible from both internal and external domains
- [x] Update cloudflare.tf DNS records for newly migrated apps
- [x] Update Cloudflare tunnel origins for external domains (n8n-webhook, pocket-id, home-assistant)