### PR TITLE
fix(longhorn): use public OIDC issuer URL for oauth2-proxy

### DIFF
--- a/kubernetes/infrastructure/talos1018/storage/longhorn/config/oauth2-proxy.yaml
+++ b/kubernetes/infrastructure/talos1018/storage/longhorn/config/oauth2-proxy.yaml
@@ -19,7 +19,7 @@ spec:
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.1
           args:
             - --provider=oidc
-            - --oidc-issuer-url=https://pid.${CLUSTER_DOMAIN}
+            - --oidc-issuer-url=https://pid.${DOMAIN}
             - --upstream=http://longhorn-frontend:80
             - --http-address=0.0.0.0:4180
             - --redirect-url=https://longhorn.${CLUSTER_DOMAIN}/oauth2/callback


### PR DESCRIPTION
## Summary

- oauth2-proxy was configured with the internal cluster URL as the OIDC issuer
- Pocket ID's discovery document returns its public external URL as the issuer
- oauth2-proxy enforces that the configured issuer matches the one returned by the provider, causing startup failure

## Fix

Change `--oidc-issuer-url` from internal cluster URL to public external URL.