### PR TITLE
feat(pocket-id): configure SMTP via Resend for email notifications

### DIFF
--- a/kubernetes/apps/talos1018/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/security/pocket-id/app/helmrelease.yaml
@@ -39,6 +39,21 @@ spec:
                   secretKeyRef:
                     name: pocket-id-secret
                     key: MAXMIND_LICENSE_KEY
+              SMTP_HOST: smtp.resend.com
+              SMTP_PORT: "465"
+              SMTP_TLS: tls
+              SMTP_FROM: pid@resend.${DOMAIN}
+              SMTP_USER: resend
+              SMTP_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: pocket-id-secret
+                    key: SMTP_PASSWORD
+              EMAILS_VERIFIED: "true"
+              EMAIL_LOGIN_NOTIFICATION_ENABLED: "true"
+              EMAIL_ONE_TIME_ACCESS_AS_ADMIN_ENABLED: "true"
+              EMAIL_ONE_TIME_ACCESS_AS_UNAUTHENTICATED_ENABLED: "true"
+              EMAIL_API_KEY_EXPIRATION_ENABLED: "true"
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/talos1018/security/pocket-id/app/pocket-id-secret.sops.yaml
+++ b/kubernetes/apps/talos1018/security/pocket-id/app/pocket-id-secret.sops.yaml
@@ -7,6 +7,7 @@ type: Opaque
 stringData:
   ENCRYPTION_KEY: ENC[AES256_GCM,data:LgmE3QXiRPKUcXyr/adovoBlchdve+gzn1SqNX4uRBW6NUCOWsmeLmrAHNY=,iv:EpZhqM8Qb4BoYDUqNyRNwIwFTljdHcJcmUXG/0gveOc=,tag:iWa17Sc6EJ6QJP5RB6Vi/Q==,type:str]
   MAXMIND_LICENSE_KEY: ENC[AES256_GCM,data:802ZdDDYs5u1NtV1LpAIuJnWuMGaluQCcTAqE4rQ0C1u8Fs/u11rjg==,iv:ndg+x8FhzSzkwI15AZwV2Fp8ZGOpyiUz03jp7q9+R3s=,tag:gO9yvkOr1bgxsIRg7DRd4Q==,type:str]
+  SMTP_PASSWORD: ENC[AES256_GCM,data:LJRKgtIjYg/bvVj3pmT/4Yn5VU42gRQQkaAM6DKFroY5C529,iv:fgoz/OOtWzHQlB/6BMBn8nAvT1es94SD7keHlsezZVo=,tag:uTCqBF0tkmhCfRavcUuMeQ==,type:str]
 sops:
   age:
     - recipient: age1kesma5f5dadlzdl5lzgrtxl6e8z8frf7njsfnlnprzan0lmzgdmstnd39u
@@ -18,8 +19,8 @@ sops:
         emFLbTBueG1NVGJEVURFZjBtd1NBa0EKghNbxbGmXyKubPhwBk7t3cUaG5HETS7A
         d02aiX4eYpiPUbYTBxw1tACdrjidMGSlvv/ISgWnCxt/TEzywVlXXw==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-01-12T10:49:07Z"
-  mac: ENC[AES256_GCM,data:0MAIwCSbCVUX10IKr/RH2Nx8YvhZkg2LOE2480WxNpd9Htr5bt7Ct3mvbJCbQhJ/j3bAyDqOLbKaFQPxv9pVc1Fi0Ba1emoHUMVN4xlUX3DkPyEJu08kBUZgLxslMZWpdLehZrMJdza2b/dj8UyR7s0CioLhL3Wk9YgYafjKWq4=,iv:XGSuKh5ehb2/2YN37WnIKT9SeF4frfwdY9b9HTtnoK8=,tag:8rWbQGLKUIvR3IkWgj9zZw==,type:str]
+  lastmodified: "2026-03-27T11:19:56Z"
+  mac: ENC[AES256_GCM,data:zwGaLRHDm8HMBxYdvm5vkbZLIB0WYZA3BmRm1GHM4GgMmRYq3zJHE/m0TECtE8o8oRg5WumzeEa87eZa8PY/xGyDA0rB5gp+W4pNyWhf3zFhOz7xDrEDKmni4iKHZXDAcQar59SY/EITsf1bgx2hRMYQeI16FAwJzeQrB79cZbo=,iv:FlotqShjv7KAFqyBYTIs4y1XWPJRtLv7lAvHNTSLDQk=,tag:P+WKoz0hi5fUFcPO2uUcjw==,type:str]
   encrypted_regex: ^(data|stringData)$
   mac_only_encrypted: true
-  version: 3.11.0
+  version: 3.12.2


### PR DESCRIPTION
## Summary

- Configure Resend SMTP (port 465, TLS) for Pocket ID email delivery
- Enable login notifications, one-time access codes, and API key expiry alerts
- Set `EMAILS_VERIFIED=true` — fixes oauth2-proxy `email_verified` claim rejection

## Test plan

- [ ] Pocket ID pod restarts cleanly with new env vars
- [ ] One-time access code email arrives when requested
- [ ] Longhorn oauth2-proxy authenticates successfully (email_verified now set)