### PR TITLE
fix(pocket-id): disable UI config to enforce env var settings

### DIFF
--- a/kubernetes/apps/talos1018/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/security/pocket-id/app/helmrelease.yaml
@@ -49,6 +49,7 @@ spec:
                   secretKeyRef:
                     name: pocket-id-secret
                     key: SMTP_PASSWORD
+              UI_CONFIG_DISABLED: "true"
               EMAILS_VERIFIED: "true"
               EMAIL_LOGIN_NOTIFICATION_ENABLED: "true"
               EMAIL_ONE_TIME_ACCESS_AS_ADMIN_ENABLED: "true"


### PR DESCRIPTION
Set `UI_CONFIG_DISABLED=true` so that SMTP and email feature flags from env vars take effect instead of database-stored UI values.