### PR TITLE
fix(longhorn): enable PKCE S256 in oauth2-proxy

### DIFF
--- a/kubernetes/infrastructure/talos1018/storage/longhorn/config/oauth2-proxy.yaml
+++ b/kubernetes/infrastructure/talos1018/storage/longhorn/config/oauth2-proxy.yaml
@@ -27,6 +27,7 @@ spec:
             - --cookie-secure=true
             - --cookie-name=_oauth2_proxy_longhorn
             - --silence-ping-logging=true
+            - --code-challenge-method=S256
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               valueFrom:


### PR DESCRIPTION
Pocket ID supports PKCE and recommends it. Adds `--code-challenge-method=S256` to oauth2-proxy to use it.