### PR TITLE
feat(gateway-api): migrate remaining ingress-nginx apps to HTTPRoute

### DIFF
--- a/kubernetes/apps/talos1018/observability/alertmanager/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/alertmanager/app/helmrelease.yaml
@@ -25,24 +25,7 @@ spec:
     persistence:
       enabled: false
     ingress:
-      enabled: true
-      className: nginx
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        gethomepage.dev/enabled: "true"
-        gethomepage.dev/group: Observability
-        gethomepage.dev/icon: sh-alertmanager.svg
-        gethomepage.dev/name: Alertmanager
-        gethomepage.dev/app: alertmanager
-      hosts:
-        - host: alertmanager.${CLUSTER_DOMAIN}
-          paths:
-            - path: /
-              pathType: Prefix
-      tls:
-        - secretName: alertmanager-tls
-          hosts:
-            - alertmanager.${CLUSTER_DOMAIN}
+      enabled: false
     # Placeholder configuration — TODO: add receivers
     config:
       global:

--- a/kubernetes/apps/talos1018/observability/alertmanager/app/httproute.yaml
+++ b/kubernetes/apps/talos1018/observability/alertmanager/app/httproute.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Observability
+    gethomepage.dev/icon: sh-alertmanager.svg
+    gethomepage.dev/name: Alertmanager
+    gethomepage.dev/app: alertmanager
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "alertmanager.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: alertmanager
+          port: 9093

--- a/kubernetes/apps/talos1018/observability/alertmanager/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/observability/alertmanager/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 namespace: observability
 resources:
   - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-logs/app/helmrelease.yaml
@@ -33,21 +33,17 @@ spec:
       service:
         clusterIP: ""
       ingress:
-        enabled: true
-        ingressClassName: nginx
-        annotations:
-          cert-manager.io/cluster-issuer: letsencrypt
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/group: Observability
-          gethomepage.dev/icon: si-victoriametrics
-          gethomepage.dev/name: VictoriaLogs
-          gethomepage.dev/app: victoria-logs
-        hosts:
-          - name: vlogs.${CLUSTER_DOMAIN}
-            path:
-              - /
-            port: http
-        tls:
-          - secretName: victoria-logs-tls
-            hosts:
-              - vlogs.${CLUSTER_DOMAIN}
+        enabled: false
+    route:
+      enabled: true
+      annotations:
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/group: Observability
+        gethomepage.dev/icon: si-victoriametrics
+        gethomepage.dev/name: VictoriaLogs
+        gethomepage.dev/app: victoria-logs
+      parentRefs:
+        - name: main-gateway
+          namespace: network
+      hostnames:
+        - "vlogs.${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
@@ -35,24 +35,7 @@ spec:
       service:
         clusterIP: ""
       ingress:
-        enabled: true
-        ingressClassName: nginx
-        annotations:
-          cert-manager.io/cluster-issuer: letsencrypt
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/group: Observability
-          gethomepage.dev/icon: si-victoriametrics
-          gethomepage.dev/name: VictoriaMetrics
-          gethomepage.dev/app: victoria-metrics
-        hosts:
-          - name: vm.${CLUSTER_DOMAIN}
-            path:
-              - /
-            port: http
-        tls:
-          - secretName: victoria-metrics-tls
-            hosts:
-              - vm.${CLUSTER_DOMAIN}
+        enabled: false
       # Built-in scraping (replaces separate vmagent)
       scrape:
         enabled: true
@@ -203,6 +186,19 @@ spec:
                     - __meta_kubernetes_endpoint_port_name
                   action: keep
                   regex: longhorn-backend;manager
+    route:
+      enabled: true
+      annotations:
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/group: Observability
+        gethomepage.dev/icon: si-victoriametrics
+        gethomepage.dev/name: VictoriaMetrics
+        gethomepage.dev/app: victoria-metrics
+      parentRefs:
+        - name: main-gateway
+          namespace: network
+      hostnames:
+        - "vm.${CLUSTER_DOMAIN}"
     # Standalone charts are used for these — disable the bundled ones
     vmagent:
       enabled: false

--- a/kubernetes/apps/talos1018/self-hosted/wishlist/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/wishlist/app/helmrelease.yaml
@@ -43,28 +43,27 @@ spec:
         ports:
           http:
             port: &port 3280
-    ingress:
+    route:
       app:
-        className: nginx
         annotations:
-          cert-manager.io/cluster-issuer: letsencrypt
           gethomepage.dev/enabled: "true"
           gethomepage.dev/group: Apps
           gethomepage.dev/icon: sh-cmintey-wishlist.png
           gethomepage.dev/name: Wishlist
           gethomepage.dev/app: wishlist
-        enabled: true
-        hosts:
-          - host: &hostName wishlist.${DOMAIN}
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: *port
-        tls:
-          - hosts:
-              - *hostName
-            secretName: wishlist-tls
+        parentRefs:
+          - name: main-gateway
+            namespace: network
+        hostnames:
+          - "wishlist.${DOMAIN}"
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: app
+                port: *port
     persistence:
       data:
         existingClaim: wishlist-data


### PR DESCRIPTION
## Summary

- **victoria-metrics**: disable chart ingress, add native `route:` via VM chart
- **victoria-logs**: disable chart ingress, add native `route:` via VM chart
- **alertmanager**: disable chart ingress, add standalone `httproute.yaml`
- **wishlist**: replace `ingress:` with native `route:` via app-template

All cluster-internal apps (`vm`, `vlogs`, `alertmanager`) have corresponding AAAA DNS records added in fmurodov-tf.

Wishlist uses existing cloudflared tunnel CNAME — tunnel origin update needed on Cloudflare dashboard.

## Test plan
- [ ] All 4 HTTPRoutes `Accepted: True`
- [ ] `vm.${CLUSTER_DOMAIN}` reachable via gateway
- [ ] `vlogs.${CLUSTER_DOMAIN}` reachable via gateway
- [ ] `alertmanager.${CLUSTER_DOMAIN}` reachable via gateway
- [ ] `wishlist.${DOMAIN}` reachable via cloudflared tunnel