### PR TITLE
fix(gateway-api): fix HTTPRoute config for VM charts and wishlist

### DIFF
--- a/kubernetes/apps/talos1018/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-logs/app/helmrelease.yaml
@@ -34,16 +34,16 @@ spec:
         clusterIP: ""
       ingress:
         enabled: false
-    route:
-      enabled: true
-      annotations:
-        gethomepage.dev/enabled: "true"
-        gethomepage.dev/group: Observability
-        gethomepage.dev/icon: si-victoriametrics
-        gethomepage.dev/name: VictoriaLogs
-        gethomepage.dev/app: victoria-logs
-      parentRefs:
-        - name: main-gateway
-          namespace: network
-      hostnames:
-        - "vlogs.${CLUSTER_DOMAIN}"
+      route:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Observability
+          gethomepage.dev/icon: si-victoriametrics
+          gethomepage.dev/name: VictoriaLogs
+          gethomepage.dev/app: victoria-logs
+        parentRefs:
+          - name: main-gateway
+            namespace: network
+        hostnames:
+          - "vlogs.${CLUSTER_DOMAIN}"

--- a/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
@@ -186,19 +186,19 @@ spec:
                     - __meta_kubernetes_endpoint_port_name
                   action: keep
                   regex: longhorn-backend;manager
-    route:
-      enabled: true
-      annotations:
-        gethomepage.dev/enabled: "true"
-        gethomepage.dev/group: Observability
-        gethomepage.dev/icon: si-victoriametrics
-        gethomepage.dev/name: VictoriaMetrics
-        gethomepage.dev/app: victoria-metrics
-      parentRefs:
-        - name: main-gateway
-          namespace: network
-      hostnames:
-        - "vm.${CLUSTER_DOMAIN}"
+      route:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Observability
+          gethomepage.dev/icon: si-victoriametrics
+          gethomepage.dev/name: VictoriaMetrics
+          gethomepage.dev/app: victoria-metrics
+        parentRefs:
+          - name: main-gateway
+            namespace: network
+        hostnames:
+          - "vm.${CLUSTER_DOMAIN}"
     # Standalone charts are used for these — disable the bundled ones
     vmagent:
       enabled: false

--- a/kubernetes/apps/talos1018/self-hosted/wishlist/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/wishlist/app/helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
             port: &port 3280
     route:
       app:
+        enabled: true
         annotations:
           gethomepage.dev/enabled: "true"
           gethomepage.dev/group: Apps


### PR DESCRIPTION
## Summary

Fixes HTTPRoutes that weren't created after #357:

- **victoria-metrics / victoria-logs**: `route:` must be nested under `server:` per the VM chart schema — was incorrectly placed at top level
- **wishlist**: `enabled: true` was missing from the app-template `route:` block

## Test plan
- [ ] `vm.${CLUSTER_DOMAIN}` HTTPRoute created and `Accepted: True`
- [ ] `vlogs.${CLUSTER_DOMAIN}` HTTPRoute created and `Accepted: True`
- [ ] `wishlist.${DOMAIN}` HTTPRoute created and `Accepted: True`