### PR TITLE
chore: standardize namespace handling, add retryInterval, fix IPv6

### DIFF
--- a/.github/workflows/validate-flux.yaml
+++ b/.github/workflows/validate-flux.yaml
@@ -8,6 +8,8 @@ on:
     tags-ignore: ["*"]
     paths:
       - "kubernetes/**"
+      - "scripts/validate-flux.sh"
+      - ".yamllint.yaml"
       - ".github/workflows/validate-flux.yaml"
 
 jobs:
@@ -24,5 +26,7 @@ jobs:
         uses: fluxcd/pkg/actions/kubeconform@357bbcc3462ccf78cc17fd0b9b7d498b1848bf14 # main
       - name: Setup kustomize
         uses: fluxcd/pkg/actions/kustomize@357bbcc3462ccf78cc17fd0b9b7d498b1848bf14 # main
+      - name: Setup yamllint
+        run: pip install yamllint
       - name: Validate manifests
         run: ./scripts/validate.sh flux

--- a/.github/workflows/validate-talos.yaml
+++ b/.github/workflows/validate-talos.yaml
@@ -10,6 +10,7 @@ on:
     tags-ignore: ["*"]
     paths:
       - "talos/**/*.yaml"
+      - "scripts/validate.sh"
       - ".github/workflows/validate-talos.yaml"
 
 jobs:

--- a/.github/workflows/validate-talos.yaml
+++ b/.github/workflows/validate-talos.yaml
@@ -26,5 +26,10 @@ jobs:
           curl -sL https://talos.dev/install | sh
           talosctl version --client
 
+      - name: Install talhelper
+        run: |
+          curl -sL https://github.com/budimanjojo/talhelper/releases/latest/download/talhelper_linux_amd64.tar.gz | tar xz -C /usr/local/bin talhelper
+          talhelper --version
+
       - name: Validate Talos configurations
         run: ./scripts/validate.sh talos

--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -46,18 +46,10 @@
     },
     {
       customType: "regex",
-      description: "Match Talos factory installer images with version tags in YAML files",
-      managerFilePatterns: ["/\\.ya?ml$/"],
+      description: "Match Talos factory installer images with version tags",
+      managerFilePatterns: ["/\\.ya?ml$/", "/\\.md$/"],
       matchStrings: [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s+image: factory\\.talos\\.dev/installer/[a-f0-9]+:(?<currentValue>v\\S+)",
-      ],
-      datasourceTemplate: "github-releases",
-    },
-    {
-      customType: "regex",
-      description: "Match Talos factory installer images with version tags in Markdown files",
-      managerFilePatterns: ["/\\.md$/"],
-      matchStrings: [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.*factory\\.talos\\.dev/(installer|metal-installer)/[a-f0-9]+:(?<currentValue>v\\S+)",
       ],
       datasourceTemplate: "github-releases",

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,17 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  braces:
+    max-spaces-inside: -1
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  document-start: disable
+  truthy:
+    check-keys: false
+
+ignore:
+  - talos/talos1018/clusterconfig/
+  - kubernetes/clusters/talos1018/flux-system/

--- a/kubernetes/apps/talos1018/guest/ripe-atlas/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/guest/ripe-atlas/app/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: guest
 resources:
   - deployment.yaml
   - pvc.yaml

--- a/kubernetes/apps/talos1018/guest/ripe-atlas/ks.yaml
+++ b/kubernetes/apps/talos1018/guest/ripe-atlas/ks.yaml
@@ -18,7 +18,6 @@ spec:
     kind: GitRepository
     name: flux-system
   path: ./kubernetes/apps/talos1018/guest/ripe-atlas/app
-  targetNamespace: guest
   prune: true
   wait: true
   postBuild:

--- a/kubernetes/apps/talos1018/network/chrony/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/chrony/app/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: network
 resources:
   - daemonset.yaml
   - service.yaml

--- a/kubernetes/apps/talos1018/network/chrony/ks.yaml
+++ b/kubernetes/apps/talos1018/network/chrony/ks.yaml
@@ -11,13 +11,13 @@ spec:
     secretRef:
       name: sops-age
   interval: 1h
+  retryInterval: 1m
   timeout: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   path: "./kubernetes/apps/talos1018/network/chrony/app"
-  targetNamespace: network
   prune: true
   wait: true
   postBuild:

--- a/kubernetes/apps/talos1018/network/cloudflared/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/cloudflared/app/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: network
 resources:
   - deployment.yaml
   - cloudflared-secret.sops.yaml

--- a/kubernetes/apps/talos1018/network/cloudflared/ks.yaml
+++ b/kubernetes/apps/talos1018/network/cloudflared/ks.yaml
@@ -11,13 +11,13 @@ spec:
     secretRef:
       name: sops-age
   interval: 1h
+  retryInterval: 1m
   timeout: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   path: "./kubernetes/apps/talos1018/network/cloudflared/app"
-  targetNamespace: network
   prune: true
   wait: true
   postBuild:

--- a/kubernetes/apps/talos1018/network/multus/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/multus/app/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: network
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/talos1018/network/multus/ks.yaml
+++ b/kubernetes/apps/talos1018/network/multus/ks.yaml
@@ -7,13 +7,13 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
+  retryInterval: 1m
   timeout: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   path: "./kubernetes/apps/talos1018/network/multus/app"
-  targetNamespace: network
   prune: true
   wait: true
   healthChecks:
@@ -39,6 +39,5 @@ spec:
   dependsOn:
     - name: multus
   path: "./kubernetes/apps/talos1018/network/multus/networks"
-  targetNamespace: network
   prune: true
   wait: true

--- a/kubernetes/apps/talos1018/network/multus/networks/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/multus/networks/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: network
 resources:
   - ./macvlan2.yaml
   - ./macvlan3.yaml

--- a/kubernetes/apps/talos1018/network/netbootxyz/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/netbootxyz/app/kustomization.yaml
@@ -2,9 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: netbootxyz
+namespace: network
 resources:
-  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/kubernetes/apps/talos1018/network/netbootxyz/app/namespace.yaml
+++ b/kubernetes/apps/talos1018/network/netbootxyz/app/namespace.yaml
@@ -1,6 +1,0 @@
----
-# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: netbootxyz

--- a/kubernetes/apps/talos1018/network/netbootxyz/ks.yaml
+++ b/kubernetes/apps/talos1018/network/netbootxyz/ks.yaml
@@ -11,13 +11,13 @@ spec:
     secretRef:
       name: sops-age
   interval: 1h
+  retryInterval: 1m
   timeout: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   path: "./kubernetes/apps/talos1018/network/netbootxyz/app"
-  targetNamespace: network
   prune: true
   wait: true
   postBuild:

--- a/kubernetes/apps/talos1018/network/openspeedtest/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/network/openspeedtest/app/kustomization.yaml
@@ -2,9 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: openspeedtest
+namespace: network
 resources:
-  - namespace.yaml
   - deployment.yaml
   - service.yaml
   - httproute.yaml

--- a/kubernetes/apps/talos1018/network/openspeedtest/app/namespace.yaml
+++ b/kubernetes/apps/talos1018/network/openspeedtest/app/namespace.yaml
@@ -1,6 +1,0 @@
----
-# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openspeedtest

--- a/kubernetes/apps/talos1018/network/openspeedtest/ks.yaml
+++ b/kubernetes/apps/talos1018/network/openspeedtest/ks.yaml
@@ -11,13 +11,13 @@ spec:
     secretRef:
       name: sops-age
   interval: 1h
+  retryInterval: 1m
   timeout: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   path: "./kubernetes/apps/talos1018/network/openspeedtest/app"
-  targetNamespace: network
   prune: true
   wait: true
   postBuild:

--- a/kubernetes/infrastructure/talos1018/storage/longhorn/config/oauth2-proxy.yaml
+++ b/kubernetes/infrastructure/talos1018/storage/longhorn/config/oauth2-proxy.yaml
@@ -21,7 +21,7 @@ spec:
             - --provider=oidc
             - --oidc-issuer-url=https://pid.${DOMAIN}
             - --upstream=http://longhorn-frontend:80
-            - --http-address=0.0.0.0:4180
+            - --http-address=[::]:4180
             - --redirect-url=https://longhorn.${CLUSTER_DOMAIN}/oauth2/callback
             - --email-domain=*
             - --cookie-secure=true

--- a/scripts/validate-flux.sh
+++ b/scripts/validate-flux.sh
@@ -42,6 +42,21 @@ kustomize_config="kustomization.yaml"
 kubeconform_flags=("-skip=Secret")
 kubeconform_config=("-strict" "-ignore-missing-schemas" "-schema-location" "default" "-schema-location" "/tmp/flux-crd-schemas" "-verbose")
 
+# Run yamllint if available
+if command -v yamllint &> /dev/null; then
+    echo "INFO - Running yamllint"
+    cd "$(git rev-parse --show-toplevel)" || exit 1
+    if ! yamllint -c .yamllint.yaml kubernetes/ talos/; then
+        echo "❌ yamllint found errors"
+        exit 1
+    fi
+    echo "✅ yamllint passed"
+    echo ""
+    cd "$(git rev-parse --show-toplevel)/kubernetes" || exit 1
+else
+    echo "INFO - yamllint not found, skipping lint"
+fi
+
 echo "INFO - Downloading Flux OpenAPI schemas"
 mkdir -p /tmp/flux-crd-schemas/master-standalone-strict
 curl -sL https://github.com/fluxcd/flux2/releases/latest/download/crd-schemas.tar.gz | tar zxf - -C /tmp/flux-crd-schemas/master-standalone-strict
@@ -71,6 +86,24 @@ find . -type f -name $kustomize_config -print0 | while IFS= read -r -d $'\0' fil
       exit 1
     fi
 done
+
+# Check for duplicate resources across leaf kustomizations (app/ directories only)
+echo "INFO - Checking for duplicate resources across app kustomizations"
+DUPES_FILE=$(mktemp)
+find . -path "*/app/$kustomize_config" -o -path "*/config/$kustomize_config" -o -path "*/networks/$kustomize_config" | \
+  while IFS= read -r file; do
+    kustomize build "${file/%$kustomize_config}" "${kustomize_flags[@]}" 2>/dev/null | \
+      yq e -N '[.kind, .metadata.name, .metadata.namespace // "default"] | join("/")' - 2>/dev/null
+done | sort | uniq -d > "$DUPES_FILE"
+
+if [ -s "$DUPES_FILE" ]; then
+    echo "❌ Duplicate resources found across kustomizations:"
+    cat "$DUPES_FILE" | sed 's/^/  - /'
+    rm -f "$DUPES_FILE"
+    exit 1
+fi
+rm -f "$DUPES_FILE"
+echo "✅ No duplicate resources found"
 
 echo ""
 echo "✅ All Flux/Kubernetes manifests are valid!"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -33,9 +33,26 @@ if [ "$VALIDATE_TALOS" = true ]; then
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
 
+    # Validate talconfig.yaml with talhelper if available
+    if command -v talhelper &> /dev/null; then
+        echo "🔎 Validating talconfig.yaml with talhelper..."
+        for talconfig in $(find talos -name "talconfig.yaml" 2>/dev/null | sort); do
+            if talhelper validate talconfig "$talconfig" --no-substitute; then
+                echo "✅ $talconfig is valid"
+            else
+                echo "❌ $talconfig validation failed"
+                VALIDATION_FAILED=1
+            fi
+        done
+        echo ""
+    else
+        echo "⚠️  talhelper is not installed - skipping talconfig validation"
+        echo ""
+    fi
+
     # Check if talosctl is installed
     if ! command -v talosctl &> /dev/null; then
-        echo "⚠️  talosctl is not installed - skipping Talos validation"
+        echo "⚠️  talosctl is not installed - skipping Talos node config validation"
         echo ""
     else
         echo "📦 talosctl version:"


### PR DESCRIPTION
## Summary
- **Namespace standardization**: Replace `targetNamespace` in ks.yaml with `namespace:` in app/kustomization.yaml for 6 apps (chrony, cloudflared, multus, netbootxyz, openspeedtest, ripe-atlas) — aligns with the repo pattern used by 25+ other apps
- **Fix namespace mismatch**: netbootxyz and openspeedtest had `namespace: <wrong-ns>` in kustomization.yaml while `targetNamespace: network` in ks.yaml was silently overriding it. Now both say `network` consistently
- **Remove orphaned namespace.yaml**: netbootxyz and openspeedtest created unused namespaces (`netbootxyz`/`openspeedtest`) — the `network` namespace is already managed by `network/namespace.yaml`
- **Add missing retryInterval**: 5 network ks.yaml files were missing `retryInterval: 1m` (every other app has it)
- **Fix Longhorn oauth2-proxy IPv6**: Changed listen address from `0.0.0.0:4180` to `[::]:4180` for dual-stack support
- **Consolidate Renovate config**: Merged two nearly identical Talos factory installer custom managers into one

## Test plan
- [x] `./scripts/validate.sh` passes (ran by pre-commit hook)
- [ ] Flux reconciles successfully after merge
- [ ] Verify netbootxyz and openspeedtest still deploy to `network` namespace