### PR TITLE
fix(longhorn): add https:// scheme to B2 backup endpoint

### DIFF
--- a/kubernetes/infrastructure/talos1018/storage/longhorn/config/backup-b2-secret.sops.yaml
+++ b/kubernetes/infrastructure/talos1018/storage/longhorn/config/backup-b2-secret.sops.yaml
@@ -6,7 +6,7 @@ metadata:
 type: Opaque
 stringData:
   AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:h/oCGuInS+kVUJyO7pxcADZEgFYwiexgdw==,iv:Xyhz81yrSZ/1N2WxCczFBYgnm6nOqIhoYhvYuYPiPTQ=,tag:53bpPi5n/S+WwOp0NXT69Q==,type:str]
-  AWS_ENDPOINTS: ENC[AES256_GCM,data:IOMomG9H8QTEzqlA8mAGtN5sdEBxacStJtA4toL6CIXe,iv:ocMNOFjXYnwBbGs6B/q6ul/nJhTA/hDLGsqtwtX+BUA=,tag:lojz1SqapPK9H8xfbiB+Cw==,type:str]
+  AWS_ENDPOINTS: ENC[AES256_GCM,data:ch7EalCEmgQlRVWekwZ6jac/oluPrskOamHf0exUZpmO1XZyasWDcS8=,iv:YAoafx0aDMlaGHSpW2+YrqvKOZ8L54JKkV/xriP0uvc=,tag:bmv2sL4C1tD318Gs2wp/1Q==,type:str]
   AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:n+WXpRHCeJJhWavTfKcuKRWlPdcUdwrlQPRAJm9YeA==,iv:86MsasGHDRgN5rzDg99I4btRqn0VoCKvb/oALLCpOJ4=,tag:jEpfpfZuoq3bFkgttYRR3A==,type:str]
 sops:
   age:
@@ -19,7 +19,7 @@ sops:
         dVNkY1M1OTlpY0JHV1BFSFZpQ1hHTWMKO2w+O0bOm9dVmtrxb/WPIVquw0wcwGlr
         ynUhnHIZ8OKIfTCQCj07wgl+I2zJ0ufS5yzRJqz7ksv4ubV3cC2v7w==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2026-01-14T14:25:41Z"
-  mac: ENC[AES256_GCM,data:tU9UZAF4mQIV13hDrJBtvqoAbsCZGRKIfbceu8l+cFz0pYNxTP9yPihdpjGIp4zwb6A84lXEKuk9JLVpv8WMANSyIXUdOyV0GdgZMScJFTKRdYP9IuJ5o0uOymm5WK/k6jZc4RYSxnHoKO3P+/EZJA/C6kQVmwG2RHcvNSan2ww=,iv:+1AMbFB53DTkDi7m3FPoXEu9JZIk6jdilxp9yWN+w14=,tag:wAbKPjuLFqq5upJKFL0Kjg==,type:str]
+  lastmodified: "2026-03-30T12:06:01Z"
+  mac: ENC[AES256_GCM,data:u96E2QJhNVb8A0N0/5VpmFdLyZOFvtbKRUwW22vm1C+gfmzEX3XghNR0tecn+FtdvHbA8rNfoz/9qGDDvmNftX1X81f5moamSa7i0LfswtPL/8mokeQhJNHC2r5Ed6xpiP4hsDaXPeRf9hkLzc1g2hHC5xfNUOpmFc7H824/KM8=,iv:d6GsqJo4jCW0FdtEH3ZEqxah+6rQE5K4uQsAuc8vIM8=,tag:qmWrR078CQXww1azp3+1rw==,type:str]
   encrypted_regex: ^(data|stringData)$
-  version: 3.11.0
+  version: 3.12.2


### PR DESCRIPTION
## Summary
- Longhorn 1.11.0 upgraded its AWS SDK which now requires `AWS_ENDPOINTS` to be a full URI with scheme prefix
- The previous value was just the hostname (`s3.eu-central-003.backblazeb2.com`), causing backup target to become unavailable since the 1.11.0 upgrade on 2026-02-01
- Added `https://` prefix to restore backup connectivity

## Test plan
- [ ] Verify backup target shows as available in Longhorn UI
- [ ] Confirm daily backup recurring job executes successfully