### PR TITLE
feat(longhorn): add daily snapshot cleanup recurring job

### DIFF
--- a/kubernetes/infrastructure/talos1018/storage/longhorn/config/daily-snapshot-cleanup.yaml
+++ b/kubernetes/infrastructure/talos1018/storage/longhorn/config/daily-snapshot-cleanup.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: daily-snapshot-cleanup
+  namespace: longhorn-system
+spec:
+  cron: "0 1 * * *"
+  task: "snapshot-cleanup"
+  retain: 0
+  concurrency: 1
+  groups:
+    - default
+  labels:
+    schedule: "daily"

--- a/kubernetes/infrastructure/talos1018/storage/longhorn/config/kustomization.yaml
+++ b/kubernetes/infrastructure/talos1018/storage/longhorn/config/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./backup-secret.sops.yaml
   - ./backup-b2-secret.sops.yaml
   - ./daily-backup.yaml
+  - ./daily-snapshot-cleanup.yaml
   - ./oauth2-proxy-secret.sops.yaml
   - ./oauth2-proxy.yaml
   - ./httproute.yaml


### PR DESCRIPTION
## Summary
- Adds a `daily-snapshot-cleanup` Longhorn RecurringJob that runs at 1:00 AM daily
- Applies to all volumes via the `default` group — no per-PVC labels needed
- Prevents snapshot bloat from backup jobs filling up volume capacity (e.g. matter-server volume was at 1.8GB/2GB actual size due to accumulated snapshots)

## Test plan
- [ ] Verify the RecurringJob is created in `longhorn-system` namespace
- [ ] Confirm snapshots are cleaned up after 1:00 AM run
- [ ] Check matter-server volume actual size decreases after cleanup