### PR TITLE
feat(security): add trivy-operator for vulnerability scanning

### DIFF
--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -162,6 +162,10 @@ spec:
           gnetId: 14950
           revision: 18
           datasource: VictoriaMetrics
+        trivy-operator:
+          gnetId: 17813
+          revision: 3
+          datasource: VictoriaMetrics
 
     ingress:
       enabled: false

--- a/kubernetes/apps/talos1018/security/trivy-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/security/trivy-operator/app/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app trivy-operator
+spec:
+  chart:
+    spec:
+      chart: trivy-operator
+      sourceRef:
+        kind: HelmRepository
+        name: aquasecurity
+  interval: 1h0m0s
+  values:
+    operator:
+      scanJobsConcurrentLimit: 1
+      vulnerabilityScannerScanOnlyCurrentRevisions: true
+      configAuditScannerScanOnlyCurrentRevisions: true
+      infraAssessmentScannerEnabled: false
+      resources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+    nodeCollector:
+      excludeNodes: "*"
+    serviceMonitor:
+      enabled: false
+    trivy:
+      ignoreUnfixed: true
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      slow: true

--- a/kubernetes/apps/talos1018/security/trivy-operator/app/helmrepository.yaml
+++ b/kubernetes/apps/talos1018/security/trivy-operator/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: aquasecurity
+spec:
+  interval: 1h
+  url: https://aquasecurity.github.io/helm-charts/

--- a/kubernetes/apps/talos1018/security/trivy-operator/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/security/trivy-operator/app/kustomization.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: security
 resources:
-  - ./namespace.yaml
-  - ./pocket-id/ks.yaml
-  - ./trivy-operator/ks.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/talos1018/security/trivy-operator/ks.yaml
+++ b/kubernetes/apps/talos1018/security/trivy-operator/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# trivy-operator - Kubernetes vulnerability scanning
+# Owns the 'aquasecurity' HelmRepository
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: trivy-operator
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/talos1018/security/trivy-operator/app
+  prune: true
+  wait: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: trivy-operator
+      namespace: security


### PR DESCRIPTION
## Summary
- Add Aqua Security trivy-operator to the `security` namespace for Kubernetes workload vulnerability scanning
- Configure with homelab-friendly defaults: single concurrent scan, ignore unfixed CVEs, no node scanning
- Add trivy-operator Grafana dashboard (gnetId 17813) for vulnerability visualization

## Test plan
- [ ] Verify Flux reconciles trivy-operator successfully: `flux get kustomizations trivy-operator`
- [ ] Confirm operator pod is running: `kubectl get pods -n security -l app.kubernetes.io/name=trivy-operator`
- [ ] Check vulnerability reports are being generated: `kubectl get vulnerabilityreports -A`
- [ ] Verify Grafana dashboard loads correctly