### PR TITLE
fix(grafana): correct trivy-operator dashboard revision

### DIFF
--- a/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/grafana/app/helmrelease.yaml
@@ -164,7 +164,7 @@ spec:
           datasource: VictoriaMetrics
         trivy-operator:
           gnetId: 17813
-          revision: 3
+          revision: 2
           datasource: VictoriaMetrics
 
     ingress:


### PR DESCRIPTION
## Summary
- Fix trivy-operator Grafana dashboard revision from 3 to 2
- Dashboard gnetId 17813 only has revisions 1 and 2; revision 3 resulted in an empty (0 byte) download causing an EOF error during Grafana provisioning

## Test plan
- [ ] Verify Grafana pod logs no longer show EOF error for trivy-operator dashboard
- [ ] Confirm trivy-operator dashboard loads in Grafana UI