### PR TITLE
fix(trivy-operator): add prometheus scrape annotations for metrics

### DIFF
--- a/kubernetes/apps/talos1018/security/trivy-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/security/trivy-operator/app/helmrelease.yaml
@@ -13,6 +13,9 @@ spec:
         name: aquasecurity
   interval: 1h0m0s
   values:
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"
     operator:
       scanJobsConcurrentLimit: 1
       vulnerabilityScannerScanOnlyCurrentRevisions: true


### PR DESCRIPTION
## Summary
- Add `prometheus.io/scrape` and `prometheus.io/port` pod annotations to trivy-operator
- VictoriaMetrics discovers scrape targets via these annotations (kubernetes-pods job), but trivy-operator had none — so no trivy metrics were being collected

## Test plan
- [ ] After Flux reconciles, verify pod has annotations: `kubectl get pods -n security -l app.kubernetes.io/name=trivy-operator -o jsonpath='{.items[0].metadata.annotations}'`
- [ ] Query VictoriaMetrics for `trivy_*` metrics (may take ~1min after deploy)
- [ ] Confirm Grafana trivy-operator dashboard shows data