### PR TITLE
fix(victoria-metrics): honor_labels for correct trivy namespace metrics

### DIFF
--- a/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/victoria-metrics/app/helmrelease.yaml
@@ -97,6 +97,7 @@ spec:
 
             # Pod autodiscovery via prometheus.io annotations
             - job_name: kubernetes-pods
+              honor_labels: true
               kubernetes_sd_configs:
                 - role: pod
               relabel_configs:


### PR DESCRIPTION
## Summary
- Add `honor_labels: true` to the `kubernetes-pods` scrape job in VictoriaMetrics
- Trivy-operator exports metrics with a `namespace` label reflecting the scanned workload's namespace, but the relabel config was overwriting it with `security` (the operator pod's namespace)
- With `honor_labels`, the metric's original `namespace` label is preserved, so the Grafana dashboard "Number of Vulnerabilities by namespace" panel shows all namespaces correctly

## Test plan
- [ ] After Flux reconciles, query `trivy_image_vulnerabilities` and verify `namespace` label shows actual workload namespaces (not just `security`)
- [ ] Confirm Grafana trivy-operator dashboard shows vulnerabilities broken down by all namespaces