### PR TITLE
fix(matter-server): increase PVC size from 2Gi to 5Gi

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/pvc.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/pvc.yaml
@@ -13,4 +13,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 2Gi
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- Increase matter-server PVC from 2Gi to 5Gi to prevent Longhorn snapshot accumulation from filling the volume

## Test plan
- [ ] Verify Longhorn volume expands after Flux reconcile