### PR TITLE
fix(security): fix podinfo, piaware, and planefinder securityContext issues

### DIFF
--- a/kubernetes/apps/talos1018/adsb/app/adsbexchange-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/adsbexchange-deployment.yaml
@@ -19,12 +19,17 @@ spec:
       labels:
         app.kubernetes.io/name: adsbexchange
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: adsbexchange
           image: ghcr.io/sdr-enthusiasts/docker-adsbexchange:20250210.1909
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
+            runAsNonRoot: true
             capabilities:
               drop: [ALL]
             seccompProfile:

--- a/kubernetes/apps/talos1018/adsb/app/adsbexchange-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/adsbexchange-deployment.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
         - name: adsbexchange
           image: ghcr.io/sdr-enthusiasts/docker-adsbexchange:20250210.1909
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           envFrom:
             - secretRef:
                 name: adsb-config

--- a/kubernetes/apps/talos1018/adsb/app/flightradar24-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/flightradar24-deployment.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
         - name: flightradar24
           image: ghcr.io/sdr-enthusiasts/docker-flightradar24:1.0.48-0
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           envFrom:
             - secretRef:
                 name: adsb-config

--- a/kubernetes/apps/talos1018/adsb/app/piaware-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/piaware-deployment.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
         - name: piaware
           image: ghcr.io/sdr-enthusiasts/docker-piaware:v9.0.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           envFrom:
             - secretRef:
                 name: adsb-config

--- a/kubernetes/apps/talos1018/adsb/app/piaware-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/piaware-deployment.yaml
@@ -26,6 +26,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:
+              add: [SETUID, SETGID]
               drop: [ALL]
             seccompProfile:
               type: RuntimeDefault

--- a/kubernetes/apps/talos1018/adsb/app/planefinder-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/planefinder-deployment.yaml
@@ -26,6 +26,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:
+              add: [CHOWN, SETUID, SETGID]
               drop: [ALL]
             seccompProfile:
               type: RuntimeDefault

--- a/kubernetes/apps/talos1018/adsb/app/planefinder-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/planefinder-deployment.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
         - name: planefinder
           image: ghcr.io/sdr-enthusiasts/docker-planefinder:latest-build-427
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           envFrom:
             - secretRef:
                 name: adsb-config

--- a/kubernetes/apps/talos1018/adsb/app/radarbox-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/radarbox-deployment.yaml
@@ -22,6 +22,13 @@ spec:
       containers:
         - name: radarbox
           image: ghcr.io/sdr-enthusiasts/docker-radarbox:latest-build-715
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           envFrom:
             - secretRef:
                 name: adsb-config

--- a/kubernetes/apps/talos1018/home-automation/mosquitto/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/home-automation/mosquitto/app/deployment.yaml
@@ -18,9 +18,22 @@ spec:
       labels:
         app.kubernetes.io/name: mosquitto
     spec:
+      securityContext:
+        runAsUser: 1883
+        runAsGroup: 1883
+        fsGroup: 1883
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: mosquitto
           image: eclipse-mosquitto:2.0.22
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - containerPort: 1883
           volumeMounts:

--- a/kubernetes/apps/talos1018/homebox/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/homebox/app/deployment.yaml
@@ -20,9 +20,22 @@ spec:
       labels:
         app.kubernetes.io/name: homebox
     spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: homebox
           image: "ghcr.io/sysadminsmedia/homebox:0.24.0-rootless"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           imagePullPolicy: Always
           ports:
             - name: http

--- a/kubernetes/apps/talos1018/homebox/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/homebox/app/deployment.yaml
@@ -21,9 +21,9 @@ spec:
         app.kubernetes.io/name: homebox
     spec:
       securityContext:
-        runAsUser: 65534
-        runAsGroup: 65534
-        fsGroup: 65534
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
         fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: homebox

--- a/kubernetes/apps/talos1018/media/isponsorblocktv/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/media/isponsorblocktv/app/deployment.yaml
@@ -18,9 +18,21 @@ spec:
       labels:
         app.kubernetes.io/name: isponsorblocktv
     spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: isponsorblocktv
           image: ghcr.io/dmunozv04/isponsorblocktv:v2.6.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             limits:
               cpu: "0.001"

--- a/kubernetes/apps/talos1018/network/cloudflared/app/deployment.yaml
+++ b/kubernetes/apps/talos1018/network/cloudflared/app/deployment.yaml
@@ -21,9 +21,21 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "2000"
     spec:
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
       containers:
         - name: cloudflared
           image: cloudflare/cloudflared:2026.3.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           args:
             - tunnel
             - --no-autoupdate

--- a/kubernetes/apps/talos1018/observability/kube-state-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/observability/kube-state-metrics/app/helmrelease.yaml
@@ -13,6 +13,18 @@ spec:
         name: prometheus
   interval: 1h0m0s
   values:
+    securityContext:
+      runAsUser: 65534
+      runAsGroup: 65534
+      fsGroup: 65534
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
     resources:
       requests:
         cpu: 25m

--- a/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
@@ -30,6 +30,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
+      runAsUser: 1000
       runAsNonRoot: true
       capabilities:
         drop: [ALL]

--- a/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
@@ -27,5 +27,14 @@ spec:
         cpu: 100m
         memory: 64Mi
 
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
+
     ingress:
       enabled: false

--- a/kubernetes/apps/talos1018/self-hosted/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/n8n/app/helmrelease.yaml
@@ -41,6 +41,14 @@ spec:
                   secretKeyRef:
                     name: n8n-secret
                     key: N8N_ENCRYPTION_KEY
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              runAsNonRoot: true
+              capabilities:
+                drop: [ALL]
+              seccompProfile:
+                type: RuntimeDefault
             resources:
               requests:
                 cpu: 5m

--- a/kubernetes/apps/talos1018/self-hosted/wishlist/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/wishlist/app/helmrelease.yaml
@@ -22,6 +22,14 @@ spec:
               TOKEN_TIME: "72"
               DEFAULT_CURRENCY: "EUR"
               HOST: "::"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              runAsNonRoot: true
+              capabilities:
+                drop: [ALL]
+              seccompProfile:
+                type: RuntimeDefault
             resources:
               requests:
                 cpu: 5m

--- a/kubernetes/apps/talos1018/spoolman/app/oauth2-proxy.yaml
+++ b/kubernetes/apps/talos1018/spoolman/app/oauth2-proxy.yaml
@@ -14,9 +14,21 @@ spec:
       labels:
         app.kubernetes.io/name: oauth2-proxy
     spec:
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
       containers:
         - name: oauth2-proxy
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
           args:
             - --provider=oidc
             - --oidc-issuer-url=https://pid.${DOMAIN}


### PR DESCRIPTION
## Summary
- Fix podinfo `CreateContainerConfigError` by adding explicit `runAsUser: 1000` (image uses non-numeric user `app`)
- Fix piaware crash loop by adding `SETUID`/`SETGID` capabilities needed by s6-overlay user switching
- Fix planefinder crash loop by adding `CHOWN`/`SETUID`/`SETGID` capabilities needed by s6-overlay init
- Correct homebox UID from 65534 to 65532 to match existing data ownership
- Add `runAsNonRoot` to adsbexchange since it already runs as UID 1000

## Test plan
- [ ] Verify podinfo pods start and become Ready
- [ ] Verify piaware logs show no more `setgid(): Operation not permitted` errors
- [ ] Verify planefinder logs show no more `chown: Operation not permitted` errors
- [ ] Verify homebox can read/write its data volume