### PR TITLE
fix(security): fix podinfo, piaware, and planefinder securityContext issues

### DIFF
--- a/kubernetes/apps/talos1018/adsb/app/piaware-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/piaware-deployment.yaml
@@ -26,6 +26,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:
+              add: [SETUID, SETGID]
               drop: [ALL]
             seccompProfile:
               type: RuntimeDefault

--- a/kubernetes/apps/talos1018/adsb/app/planefinder-deployment.yaml
+++ b/kubernetes/apps/talos1018/adsb/app/planefinder-deployment.yaml
@@ -26,6 +26,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:
+              add: [CHOWN, SETUID, SETGID]
               drop: [ALL]
             seccompProfile:
               type: RuntimeDefault

--- a/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/podinfo/app/helmrelease.yaml
@@ -30,6 +30,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
+      runAsUser: 1000
       runAsNonRoot: true
       capabilities:
         drop: [ALL]


### PR DESCRIPTION
## Summary
- Fix podinfo `CreateContainerConfigError` by adding explicit `runAsUser: 1000` (image uses non-numeric user `app`)
- Fix piaware crash loop by adding `SETUID`/`SETGID` capabilities needed by s6-overlay user switching
- Fix planefinder crash loop by adding `CHOWN`/`SETUID`/`SETGID` capabilities needed by s6-overlay init

Follow-up to #398.

## Test plan
- [ ] Verify podinfo pods start and become Ready
- [ ] Verify piaware logs show no more `setgid(): Operation not permitted` errors
- [ ] Verify planefinder starts without `chown: Operation not permitted` errors