### PR TITLE
feat(home-automation): expose matter-server dashboard via oauth2-proxy

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
               TZ: ${TIMEZONE}
               MATTER_SERVER__INSTANCE_NAME: "{{ .Release.Name }}"
               DISABLE_DASHBOARD: false
+              PRODUCTION_MODE: "true"
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/httproute.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/httproute.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.30.0/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: matter-server
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Home Automation
+    gethomepage.dev/icon: sh-matter.svg
+    gethomepage.dev/name: Matter Server
+    gethomepage.dev/app: matter-server
+    gethomepage.dev/description: Matter protocol server for Home Assistant
+spec:
+  parentRefs:
+    - name: main-gateway
+      namespace: network
+  hostnames:
+    - "matter-server.${CLUSTER_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: matter-server-oauth2-proxy
+          port: 4180

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/kustomization.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/kustomization.yaml
@@ -6,3 +6,6 @@ namespace: home-automation
 resources:
   - ./pvc.yaml
   - ./helmrelease.yaml
+  - ./oauth2-proxy.yaml
+  - ./matter-server-oauth2-proxy-secret.sops.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/matter-server-oauth2-proxy-secret.sops.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/matter-server-oauth2-proxy-secret.sops.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: Secret
+metadata:
+  name: matter-server-oauth2-proxy-secret
+stringData:
+  OAUTH2_PROXY_CLIENT_ID: ENC[AES256_GCM,data:fkHqxPc4UT49Txzz1kfrHSN7UM76cc048EonPump8X+GtlpX,iv:RAWuXtFdk/EV30vUAWiaHXKoAyBAKwPF+JwRdWoHTp8=,tag:Aq9iuiXSp/pZR8PtPSf92A==,type:str]
+  OAUTH2_PROXY_CLIENT_SECRET: ENC[AES256_GCM,data:YKiNMgYZJ4u+JV3PEFUqRLZcrn9w6iPGs4RRONRAJck=,iv:ebrao53ruLBsqA6RKDgeMA8UbCBK9ZNPOpmPSin0/bc=,tag:Z9ffeKHVNOc7EF2va8yLrA==,type:str]
+  OAUTH2_PROXY_COOKIE_SECRET: ENC[AES256_GCM,data:n8FAYdbioz5x7oUUo883GCUb5JF561y0kJSO//3oO4G1XKd+jWACF0QnKaM=,iv:SDqDR0934NY+Xbyrc36PdqPKCAhYYa5mrcGdXZtz0v0=,tag:NaC7d8nw+NZKnoeNStXa1Q==,type:str]
+sops:
+  age:
+    - recipient: age1kesma5f5dadlzdl5lzgrtxl6e8z8frf7njsfnlnprzan0lmzgdmstnd39u
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaNmZ6KzJ4TjFyNXBieHZo
+        b3BjVTNrU1ZYS0gxVmhndFNpQjRJR3lLTEc4CjdNRFBMcDhwdFl6Q1U3a0ZBd1R5
+        R0Z5S1VIVVI2dGFJbUdkYjNKMjFiaFUKLS0tIE1iYkNzUTh3OEg2dFFZR0dTU1pa
+        cWwwN2IxdVB3dFA5eTQwL2R1c0lEWTAKefFRcW8+T/79a33qbfWiV1l7lLFue0Qu
+        wKGelttk2qC6Aih3RWApbqrL4UKqWPL8gYAoIVgoJ9vvsNkgEo65eg==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-04-06T19:32:51Z"
+  mac: ENC[AES256_GCM,data:ARiJRbzPEullaNO4eTOvESrLy3VA5RnZXEUrYTnSrtVQgEIIe/0gAVuUYqevFYs4ERo2euy5bJShO2+KfRDp/NDw35INuq0vLQHTBgyhxfNdO3IkhMMnksdxGlYIAQ/YLH00r/Yo29VOQb+Hkss49q49BpqKr8J2ZRyaWFkFU0c=,iv:7KL4SfWiozjJKYT7jZIy9GaAFEi6B5zmzvwdNrhDjVw=,tag:z0wWiYCcdwWxmY9FGRYOAg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.2

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/oauth2-proxy.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/oauth2-proxy.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matter-server-oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: matter-server-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: matter-server-oauth2-proxy
+    spec:
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.1
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          args:
+            - --provider=oidc
+            - --oidc-issuer-url=https://pid.${DOMAIN}
+            - --upstream=http://matter-server-app:5580
+            - --http-address=[::]:4180
+            - --redirect-url=https://matter-server.${CLUSTER_DOMAIN}/oauth2/callback
+            - --email-domain=*
+            - --cookie-secure=true
+            - --cookie-name=_oauth2_proxy_matter_server
+            - --silence-ping-logging=true
+            - --code-challenge-method=S256
+          env:
+            - name: OAUTH2_PROXY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: matter-server-oauth2-proxy-secret
+                  key: OAUTH2_PROXY_CLIENT_ID
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: matter-server-oauth2-proxy-secret
+                  key: OAUTH2_PROXY_CLIENT_SECRET
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: matter-server-oauth2-proxy-secret
+                  key: OAUTH2_PROXY_COOKIE_SECRET
+          ports:
+            - name: http
+              containerPort: 4180
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: matter-server-oauth2-proxy
+spec:
+  selector:
+    app.kubernetes.io/name: matter-server-oauth2-proxy
+  ports:
+    - name: http
+      port: 4180
+      targetPort: http

--- a/kubernetes/apps/talos1018/home-automation/home-assistant/ks.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/ks.yaml
@@ -16,6 +16,10 @@ spec:
   path: ./kubernetes/apps/talos1018/home-automation/home-assistant/app
   prune: true
   wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   postBuild:
     substituteFrom:
       - kind: Secret


### PR DESCRIPTION
## Summary
- Add HTTPRoute for matter-server dashboard at `matter-server.CLUSTER_DOMAIN` (internal, https-internal listener)
- Add oauth2-proxy (OIDC via Pocket ID) in front of the dashboard
- Set `PRODUCTION_MODE=true` on the container for reverse proxy compatibility
- Add SOPS decryption to `ks.yaml` (required for the new encrypted secret)

## Test plan
- [ ] Register OIDC client in Pocket ID for `matter-server.CLUSTER_DOMAIN` with redirect URI `https://matter-server.CLUSTER_DOMAIN/oauth2/callback`
- [ ] Verify Flux reconciles `home-assistant-app` kustomization without errors
- [ ] Confirm dashboard is accessible at `https://matter-server.CLUSTER_DOMAIN` after OIDC login
- [ ] Confirm Home Assistant Matter integration still connects via websocket (direct service, unaffected)