### PR TITLE
feat(home-automation): add OpenThread Border Router

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/home-assistant/app/matter-server/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
                 type: RuntimeDefault
     defaultPodOptions:
       annotations:
-        k8s.v1.cni.cncf.io/networks: network/multus-macvlan2, network/multus-macvlan3
+        k8s.v1.cni.cncf.io/networks: network/multus-macvlan2
     service:
       app:
         controller: matter-server

--- a/kubernetes/apps/talos1018/home-automation/otbr/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/otbr/app/helmrelease.yaml
@@ -1,0 +1,127 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: otbr
+spec:
+  chart:
+    spec:
+      chart: app-template
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+      version: 4.6.2
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      otbr-1:
+        type: deployment
+        replicas: 0
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: talos-1018-1
+        containers:
+          app: &container
+            image:
+              repository: openthread/border-router
+              tag: latest
+              pullPolicy: Always
+            env:
+              OT_RCP_DEVICE: "spinel+hdlc+uart:///dev/thread0?uart-baudrate=460800&uart-flow-control"
+              OT_INFRA_IF: "net1"
+              OT_THREAD_IF: "wpan0"
+              OT_REST_LISTEN_ADDR: "::"
+              OT_REST_LISTEN_PORT: "8081"
+              OT_WEB_LISTEN_ADDR: "::"
+              OT_WEB_LISTEN_PORT: "8080"
+              OT_LOG_LEVEL: "4"
+            securityContext:
+              privileged: true
+              capabilities:
+                add:
+                  - NET_ADMIN
+
+      otbr-2:
+        type: deployment
+        replicas: 1
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: talos-1018-2
+        containers:
+          app: *container
+
+      otbr-3:
+        type: deployment
+        replicas: 1
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: talos-1018-3
+        containers:
+          app: *container
+
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: network/multus-macvlan2
+
+    service:
+      otbr-1:
+        controller: otbr-1
+        ports:
+          rest:
+            port: 8081
+          web:
+            port: 8080
+      otbr-2:
+        controller: otbr-2
+        ports:
+          rest:
+            port: 8081
+          web:
+            port: 8080
+      otbr-3:
+        controller: otbr-3
+        ports:
+          rest:
+            port: 8081
+          web:
+            port: 8080
+
+    persistence:
+      data-1:
+        existingClaim: otbr-data-1
+        advancedMounts:
+          otbr-1:
+            app:
+              - path: /data
+      data-2:
+        existingClaim: otbr-data-2
+        advancedMounts:
+          otbr-2:
+            app:
+              - path: /data
+      data-3:
+        existingClaim: otbr-data-3
+        advancedMounts:
+          otbr-3:
+            app:
+              - path: /data
+      thread-dongle:
+        type: hostPath
+        hostPath: /dev/thread0
+        globalMounts:
+          - path: /dev/thread0
+      tun:
+        type: hostPath
+        hostPath: /dev/net/tun
+        globalMounts:
+          - path: /dev/net/tun

--- a/kubernetes/apps/talos1018/home-automation/otbr/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/home-automation/otbr/app/kustomization.yaml
@@ -2,9 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: home-automation
 resources:
-  - ./namespace.yaml
-  - ./mosquitto/ks.yaml
-  - ./esphome/ks.yaml
-  - ./otbr/ks.yaml
-  - ./home-assistant/ks.yaml
+  - pvc.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/talos1018/home-automation/otbr/app/pvc.yaml
+++ b/kubernetes/apps/talos1018/home-automation/otbr/app/pvc.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otbr-data-1
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/daily-backup: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otbr-data-2
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/daily-backup: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otbr-data-3
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/daily-backup: enabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/talos1018/home-automation/otbr/ks.yaml
+++ b/kubernetes/apps/talos1018/home-automation/otbr/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: otbr-app
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/apps/talos1018/home-automation/otbr/app
+  prune: true
+  wait: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: otbr
+      namespace: home-automation

--- a/talos/talos1018/talconfig.yaml
+++ b/talos/talos1018/talconfig.yaml
@@ -244,3 +244,10 @@ controlPlane:
     - |-
       cluster:
         allowSchedulingOnControlPlanes: true
+
+    # udev rules for USB Thread dongles — creates stable /dev/thread0 symlink
+    - |-
+      machine:
+        udev:
+          rules:
+            - SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="thread0", MODE="0666"


### PR DESCRIPTION
## Summary

- Add OTBR with 3 Deployment controllers (one per node) via app-template, each with its own Service for stable per-instance REST endpoints in Home Assistant
- `otbr-1` starts at `replicas: 0` (no dongle on talos-1018-1 yet), `otbr-2`/`otbr-3` active
- Multus `macvlan2` for network isolation — no `hostNetwork` needed; `OT_INFRA_IF: net1`
- Longhorn PVCs with daily backup labels for Thread network state (`otbr-data-1/2/3`)
- udev rule in Talos config for stable `/dev/thread0` symlink (vendor `10c4`, product `ea60`)
- Remove `multus-macvlan3` from matter-server (not needed)

## Home Assistant endpoints

```
http://otbr-2.home-automation.svc.cluster.local:8081
http://otbr-3.home-automation.svc.cluster.local:8081
```

## Test plan

- [ ] Flux reconciles `otbr-app` Kustomization without errors
- [ ] `otbr-2` and `otbr-3` pods start and attach to `/dev/thread0` on their respective nodes
- [ ] `otbr-1` Deployment exists at 0 replicas with no errors
- [ ] Longhorn creates 3 PVCs (`otbr-data-1/2/3`) with daily backup enabled
- [ ] REST API reachable at each endpoint from Home Assistant
- [ ] matter-server pod restarts cleanly with only `macvlan2`