### PR TITLE
fix(home-automation): disable uart flow control for Sonoff Dongle-PMG24 on otbr-3

### DIFF
--- a/kubernetes/apps/talos1018/home-automation/otbr/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/otbr/app/helmrelease.yaml
@@ -79,21 +79,21 @@ spec:
         k8s.v1.cni.cncf.io/networks: network/multus-macvlan2
 
     service:
-      otbr-1:
+      "1":
         controller: otbr-1
         ports:
           rest:
             port: 8081
           web:
             port: 8080
-      otbr-2:
+      "2":
         controller: otbr-2
         ports:
           rest:
             port: 8081
           web:
             port: 8080
-      otbr-3:
+      "3":
         controller: otbr-3
         ports:
           rest:

--- a/kubernetes/apps/talos1018/home-automation/otbr/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/home-automation/otbr/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
               repository: openthread/border-router
               tag: latest
               pullPolicy: Always
-            env:
+            env: &env
               OT_RCP_DEVICE: "spinel+hdlc+uart:///dev/thread0?uart-baudrate=460800&uart-flow-control"
               OT_INFRA_IF: "net1"
               OT_THREAD_IF: "wpan0"
@@ -67,7 +67,12 @@ spec:
           nodeSelector:
             kubernetes.io/hostname: talos-1018-3
         containers:
-          app: *container
+          app:
+            <<: *container
+            env:
+              <<: *env
+              # Sonoff Dongle-PMG24 does not have RTS/CTS wired — no hardware flow control
+              OT_RCP_DEVICE: "spinel+hdlc+uart:///dev/thread0?uart-baudrate=460800"
 
     defaultPodOptions:
       annotations:


### PR DESCRIPTION
## Summary

- Sonoff Dongle-PMG24 (talos-1018-3) does not have RTS/CTS wired, causing `otbr-agent` to hang waiting for a hardware flow control signal that never arrives
- Remove `uart-flow-control` from `OT_RCP_DEVICE` for `otbr-3` only, keeping it for `otbr-2` (SLZB-07Mg24 supports it)
- Uses YAML anchor merge (`<<: *container`, `<<: *env`) to inherit the shared container spec and override only the one differing env var