### PR TITLE
fix(helm): enable automountServiceAccountToken for multus after app-template 5.0.0 upgrade

### DIFF
--- a/kubernetes/apps/talos1018/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/network/multus/app/helmrelease.yaml
@@ -105,3 +105,4 @@ spec:
     serviceAccount:
       multus:
         enabled: true
+        automountServiceAccountToken: true


### PR DESCRIPTION
## Summary

- app-template 5.0.0 changed the default for `automountServiceAccountToken` to `false` on service accounts
- Multus needs the service account token at `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` to build its kubeconfig for API server communication
- Add `automountServiceAccountToken: true` to the multus service account definition

## Test plan

- [ ] Flux reconciles the HelmRelease
- [ ] `stern multus -n network` shows no more `ca.crt not found` errors
- [ ] Multus daemonset pods reach Running state