### PR TITLE
fix(helm): move automountServiceAccountToken to pod spec for multus

### DIFF
--- a/kubernetes/apps/talos1018/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/network/multus/app/helmrelease.yaml
@@ -20,6 +20,7 @@ spec:
           identifier: multus
         pod:
           hostNetwork: true
+          automountServiceAccountToken: true
         initContainers:
           cni-plugins:
             image:
@@ -105,4 +106,3 @@ spec:
     serviceAccount:
       multus:
         enabled: true
-        automountServiceAccountToken: true


### PR DESCRIPTION
## Summary

- Previous fix (#491) placed `automountServiceAccountToken: true` in the `serviceAccount` block, but app-template 5.0.0 schema does not allow that field there — causing a Helm upgrade schema validation failure
- Move `automountServiceAccountToken: true` to `controllers.multus.pod` where the schema does accept it

## Test plan

- [ ] Flux reconciles the HelmRelease without schema errors
- [ ] Multus daemonset pods reach Running state
- [ ] `stern multus -n network` shows no more `ca.crt not found` errors