### PR TITLE
feat(apps): add sure personal finance app

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./changedetection/ks.yaml
   - ./paperless/ks.yaml
   - ./n8n/ks.yaml
+  - ./sure/ks.yaml
   - ./wishlist/ks.yaml

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -1,0 +1,260 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app sure
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      sure:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: &sureImage
+              repository: ghcr.io/we-promise/sure
+              # renovate: datasource=docker depName=ghcr.io/we-promise/sure
+              tag: 0.7.1
+            env: &sureEnv
+              SELF_HOSTED: "true"
+              ONBOARDING_STATE: "open"
+              RAILS_FORCE_SSL: "false"
+              RAILS_ASSUME_SSL: "true"
+              PORT: "3000"
+              APP_DOMAIN: &host sure.${CLUSTER_DOMAIN}
+              DB_HOST: sure-postgres
+              DB_PORT: "5432"
+              POSTGRES_USER: &pgUser sure
+              POSTGRES_DB: &pgDb sure_production
+              REDIS_URL: redis://sure-redis:6379/1
+              EXCHANGE_RATE_PROVIDER: yahoo_finance
+              SECURITIES_PROVIDER: yahoo_finance
+              WEBAUTHN_RP_ID: *host
+              WEBAUTHN_ALLOWED_ORIGINS: https://sure.${CLUSTER_DOMAIN}
+              OIDC_ISSUER: https://pid.${CLUSTER_DOMAIN}
+              OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
+              SECRET_KEY_BASE:
+                valueFrom:
+                  secretKeyRef:
+                    name: sure-secret
+                    key: SECRET_KEY_BASE
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: sure-secret
+                    key: POSTGRES_PASSWORD
+              OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: sure-secret
+                    key: OIDC_CLIENT_ID
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: sure-secret
+                    key: OIDC_CLIENT_SECRET
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+          worker:
+            image: *sureImage
+            command:
+              - bundle
+              - exec
+              - sidekiq
+            env: *sureEnv
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
+      postgres:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          postgres:
+            image:
+              repository: postgres
+              # renovate: datasource=docker depName=postgres
+              tag: "16"
+            env:
+              POSTGRES_USER: *pgUser
+              POSTGRES_DB: *pgDb
+              PGDATA: /var/lib/postgresql/data/pgdata
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: sure-secret
+                    key: POSTGRES_PASSWORD
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [pg_isready, -U, sure, -d, sure_production]
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [pg_isready, -U, sure, -d, sure_production]
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [pg_isready, -U, sure, -d, sure_production]
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+        pod:
+          securityContext:
+            fsGroup: 999
+            fsGroupChangePolicy: OnRootMismatch
+
+      redis:
+        containers:
+          redis:
+            image:
+              repository: ghcr.io/valkey-io/valkey
+              # renovate: datasource=docker depName=ghcr.io/valkey-io/valkey
+              tag: 9.1.0
+            command:
+              - valkey-server
+              - --appendonly
+              - "yes"
+              - --dir
+              - /data
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [valkey-cli, ping]
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: [valkey-cli, ping]
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        forceRename: *app
+        primary: true
+        controller: sure
+        ports:
+          http:
+            port: 3000
+      postgres:
+        controller: postgres
+        ports:
+          postgres:
+            port: 5432
+      redis:
+        controller: redis
+        ports:
+          redis:
+            port: 6379
+
+    route:
+      app:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Apps
+          gethomepage.dev/icon: sh-maybe-finance.png
+          gethomepage.dev/name: Sure
+          gethomepage.dev/app: sure
+          gethomepage.dev/description: Personal finance
+        parentRefs:
+          - name: main-gateway
+            namespace: network
+        hostnames:
+          - *host
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: app
+                port: 3000
+
+    persistence:
+      app-data:
+        existingClaim: sure-app-data
+        advancedMounts:
+          sure:
+            app:
+              - path: /rails/storage
+            worker:
+              - path: /rails/storage
+      postgres-data:
+        existingClaim: sure-postgres-data
+        advancedMounts:
+          postgres:
+            postgres:
+              - path: /var/lib/postgresql/data
+      redis-data:
+        existingClaim: sure-redis-data
+        advancedMounts:
+          redis:
+            redis:
+              - path: /data

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: self-hosted
+resources:
+  - ./pvcs.yaml
+  - ./sure-secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/pvcs.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/pvcs.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sure-app-data
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/daily-backup: enabled
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sure-postgres-data
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/daily-backup: enabled
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sure-redis-data
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/sure-secret.sops.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/sure-secret.sops.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sure-secret
+type: Opaque
+stringData:
+  SECRET_KEY_BASE: ENC[AES256_GCM,data:vGGKQKiLYR2YH+MbfWrz7bT8yuchU/qEOZmFH571/C6vOYEgmWVkDF4DCO23wIVm5tQI/alY9MWsM2hweG0Zy4fUvFb/q79YZiWQviM28Bvn7SC+CAtPfYz+2BkaOPojNepX3GGEtyK/EWLOrqYnNJNdDF4fOU2tdCDdrW/PXX8=,iv:53Pmb2Z2cd6GwLz1DqbKLpD7zEif9aeE/KbfYRhIfYU=,tag:jvqPVzVub4KpqLAPcQPUcQ==,type:str]
+  POSTGRES_PASSWORD: ENC[AES256_GCM,data:3BEW5nsr2W+JUQ8L5F8sTvf8cMVCd2xFKCf4QhFCxGA=,iv:PSVPVYKBkT4kks63m8694svhr6yV9KxT6bGdUAxPq4E=,tag:hRtGgEJ/jojl1xQjkPrnJw==,type:str]
+  OIDC_CLIENT_ID: ENC[AES256_GCM,data:pcE5FLFmkq3qCU0YJM54tWgs3UDiaZ8ZzPIFGcQeMvWdwGhW,iv:YNIl3WjgdJjsQbCXBSYvjpMj0iBI3DdObMz3vTFJSE0=,tag:EtFLZm/yGQjov+5jXkAZsw==,type:str]
+  OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:bygziY3oaIGfi0IAyQqcgT4jEQejU4KZOHjxzD8AUSE=,iv:4lmzp6tdzD0KtB2NoVCIig4EhVBz83iYFcNd/8RUkOU=,tag:04YLe3OziwfxHCeF1blNTA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUbWpXTEVLUWhwL1d1VDJC
+        OHhVem5leUVRNWRIVDJLOHZrb0o3N09CQlJvCkI4czNtbzhDdTlLaml1U01uWHVY
+        bGpFeWxXdWJzZzkrR0VYcU50clZIYVEKLS0tIHNQczdVNzFlNlpJUmxjZXdpVlBv
+        M2lId0R0U2FZaVRsdk1xNDhCeW9uQ0UK5650/TcwIt8L6PMlo5qQuoUG0XvOrK/V
+        3uhE0+npEYFj/ZdKa2gE9QbjFDr3VIBgLSJGGFUwfY3yoKNkxk/koQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1kesma5f5dadlzdl5lzgrtxl6e8z8frf7njsfnlnprzan0lmzgdmstnd39u
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-04T14:39:09Z"
+  mac: ENC[AES256_GCM,data:b4aXyZZdOIFWk8xNyKHriYVJsQvhzh+NKm2V/4ITBPaAYJZEX+kL3yl5i/OuHpO4xGSwol1TtbCp00zBkNsJWMDsYksPmPFM82/j0a7NhI4ZOHOH29TcVHt9utRhok+9f6OqJtFCKTFjfXA/7IW88fJl/1shJLHBuuFNQEfkH/s=,iv:DQ2gBac3j/uwNPaHfYRkTKSC1RbhpdZDybN9qaU3pew=,tag:Uru2vzcoAUdaTQoCHgBmcg==,type:str]
+  version: 3.13.1

--- a/kubernetes/apps/talos1018/self-hosted/sure/ks.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Sure - Personal finance app
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sure
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-longhorn-config
+      namespace: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/talos1018/self-hosted/sure/app
+  prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  wait: true


### PR DESCRIPTION
## Summary

- Deploys [we-promise/sure](https://github.com/we-promise/sure) (self-hosted personal finance, community fork of Maybe Finance) to the `self-hosted` namespace
- Uses bjw-s app-template with three controllers co-located in one HelmRelease: `sure` (Rails web + Sidekiq worker), `postgres:16`, `valkey:9.1.0`
- Internal-only access at `sure.${CLUSTER_DOMAIN}` via the `https-internal` listener
- Pocket ID OIDC pre-wired (`/auth/openid_connect/callback` path)
- Three Longhorn PVCs: `sure-app-data` (5Gi, daily backup), `sure-postgres-data` (10Gi, daily backup), `sure-redis-data` (1Gi)
- Secrets encrypted with SOPS/age

## Test plan

- [ ] Flux reconciles `sure` Kustomization without errors
- [ ] All three pods (`sure`, `sure-postgres`, `sure-redis`) reach Running state
- [ ] Browse to `https://sure.<cluster-domain>` → onboarding screen appears
- [ ] Sign in via Pocket ID OIDC successfully
- [ ] After initial signup, flip `ONBOARDING_STATE` to `closed` in helmrelease
- [ ] Confirm Sidekiq worker logs show idle (no crash loops)
- [ ] Restart deployment and verify data persists