### PR TITLE
fix(apps): configure sure to listen on IPv6 ( 0.0.0.0 ➔ :: )

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -26,6 +26,7 @@ spec:
               RAILS_FORCE_SSL: "false"
               RAILS_ASSUME_SSL: "true"
               PORT: "3000"
+              BINDING: "::"
               APP_DOMAIN: &host sure.${CLUSTER_DOMAIN}
               DB_HOST: sure-postgres
               DB_PORT: "5432"


### PR DESCRIPTION
## Summary

- Sets `BINDING: "::"` env var so Puma binds to `[::]:3000` instead of `0.0.0.0:3000`
- This is the Sure equivalent of the `httpListenAddr: "[::]:port"` pattern used across the rest of the cluster

## Test plan

- [ ] Pod logs show `Listening on http://[::]:3000` after reconcile