### PR TITLE
fix(apps): correct sure oidc issuer url and disable local login

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -37,7 +37,9 @@ spec:
               SECURITIES_PROVIDER: yahoo_finance
               WEBAUTHN_RP_ID: *host
               WEBAUTHN_ALLOWED_ORIGINS: https://sure.${CLUSTER_DOMAIN}
-              OIDC_ISSUER: https://pid.${CLUSTER_DOMAIN}
+              AUTH_LOCAL_LOGIN_ENABLED: "false"
+              AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED: "true"
+              OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
               SECRET_KEY_BASE:
                 valueFrom:


### PR DESCRIPTION
## Summary

- Fixes `OIDC_ISSUER` from internal to public URL — Pocket ID's `APP_URL` is the external domain, which is what it puts in the JWT `iss` claim; using the internal URL causes issuer mismatch and OIDC login failures
- Adds `AUTH_LOCAL_LOGIN_ENABLED: "false"` to hide the email/password form and force SSO-only
- Adds `AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED: "true"` as emergency backdoor in case Pocket ID is unavailable

## Test plan

- [ ] OIDC login flow completes without issuer mismatch error
- [ ] Email/password form is no longer shown on the login page
- [ ] Admin can still log in with local credentials if needed (override)