### PR TITLE
fix(apps): close sure onboarding after initial setup

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
               tag: 0.7.1
             env: &sureEnv
               SELF_HOSTED: "true"
-              ONBOARDING_STATE: "open"
+              ONBOARDING_STATE: "closed"
               RAILS_FORCE_SSL: "false"
               RAILS_ASSUME_SSL: "true"
               PORT: "3000"


### PR DESCRIPTION
Flips `ONBOARDING_STATE` from `open` to `closed` now that the initial user account has been created. Prevents new self-registrations.