### PR TITLE
feat(ai): add ollama for local LLM inference

### DIFF
--- a/kubernetes/apps/talos1018/ai/kustomization.yaml
+++ b/kubernetes/apps/talos1018/ai/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./ocirepository.yaml
+  - ./ollama/ks.yaml

--- a/kubernetes/apps/talos1018/ai/namespace.yaml
+++ b/kubernetes/apps/talos1018/ai/namespace.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai

--- a/kubernetes/apps/talos1018/ai/ocirepository.yaml
+++ b/kubernetes/apps/talos1018/ai/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+  namespace: ai
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app ollama
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      ollama:
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ollama/ollama
+              # renovate: datasource=docker depName=ollama/ollama
+              tag: 0.30.6
+            env:
+              OLLAMA_HOST: "[::]:11434"
+              OLLAMA_MODELS: /data/models
+              HOME: /data
+              OLLAMA_KEEP_ALIVE: 24h
+              OLLAMA_MAX_LOADED_MODELS: "1"
+              OLLAMA_NUM_PARALLEL: "2"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 11434
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 11434
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 11434
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+              limits:
+                memory: 6Gi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        forceRename: *app
+        primary: true
+        controller: ollama
+        ipFamilyPolicy: SingleStack
+        ipFamilies: [IPv6]
+        ports:
+          http:
+            port: 11434
+
+    persistence:
+      models:
+        existingClaim: ollama-models
+        advancedMounts:
+          ollama:
+            app:
+              - path: /data

--- a/kubernetes/apps/talos1018/ai/ollama/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+resources:
+  - ./pvc.yaml
+  - ./helmrelease.yaml
+  - ./model-pull-job.yaml

--- a/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ollama-pull-llama3-2-3b
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: pull
+          # renovate: datasource=docker depName=ollama/ollama
+          image: ollama/ollama:0.30.6
+          env:
+            - name: OLLAMA_HOST
+              value: http://ollama.ai.svc.cluster.local:11434
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until ollama list >/dev/null 2>&1; do
+                echo "Waiting for ollama service to be ready..."
+                sleep 5
+              done
+              echo "Pulling llama3.2:3b..."
+              ollama pull llama3.2:3b
+              echo "Done."
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/kubernetes/apps/talos1018/ai/ollama/app/pvc.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-models
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/talos1018/ai/ollama/ks.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Ollama - local LLM inference server (OpenAI-compatible API)
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ollama
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-longhorn-config
+      namespace: flux-system
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/talos1018/ai/ollama/app
+  prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  wait: true

--- a/kubernetes/apps/talos1018/kustomization.yaml
+++ b/kubernetes/apps/talos1018/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
   # Self Hosted
   - ./self-hosted
 
+  # AI / LLM
+  - ./ai
+
   # Web Services and Apps
   - ./homepage/ks.yaml
   - ./mealie/ks.yaml


### PR DESCRIPTION
## Summary
- New `ai/` namespace + category serving Ollama (`llama3.2:3b`) for in-cluster workloads (starting with `sure` finance app for transaction classification).
- OpenAI-compatible API at `http://ollama.ai.svc.cluster.local:11434/v1` (in-cluster only, no HTTPRoute, no auth).
- Single-stack IPv6 service; container listens on `[::]:11434`.
- Flux-managed Job pulls `llama3.2:3b` once the service is reachable; adding more models = new Job with a new name.

## Test plan
- [x] `./scripts/validate.sh flux` passes; new resources show as valid (`Namespace ai`, `OCIRepository app-template`, `Kustomization ollama`, `HelmRelease ollama`, `PVC ollama-models`, `Job ollama-pull-llama3-2-3b`)
- [ ] After Flux reconciles: `flux get ks ollama -n flux-system` reports Ready=True
- [ ] `kubectl -n ai get pods,svc,pvc,job` — pod Running, PVC Bound, Job Completed
- [ ] `kubectl -n ai exec deploy/ollama -- ollama list` shows `llama3.2:3b`
- [ ] Smoke test from a curl pod hitting `/v1/chat/completions` returns a response
- [ ] Tool-calling smoke test with a sample `tools: [...]` array returns `tool_calls`

## Notes
- CPU-only inference; expect 5–15 tok/s for the 3B model.
- 20Gi PVC (no backup labels — models are re-downloadable).
- Switching `sure` to this endpoint is out of scope; do it in a follow-up by editing `sure-secret.sops.yaml` (`OPENAI_URI_BASE` → in-cluster URL) and `OPENAI_MODEL`.