### PR TITLE
feat(sure): use in-cluster ollama (llama3.2:3b)

### DIFF
--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -41,7 +41,9 @@ spec:
               AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED: "true"
               OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
-              OPENAI_MODEL: "qwen3.6-35b-a3b"
+              OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
+              OPENAI_ACCESS_TOKEN: "ollama"
+              OPENAI_MODEL: "llama3.2:3b"
               AI_DEBUG_MODE: "true"
               SECRET_KEY_BASE:
                 valueFrom:
@@ -68,16 +70,6 @@ spec:
                   secretKeyRef:
                     name: sure-secret
                     key: BRAND_FETCH_CLIENT_ID
-              OPENAI_URI_BASE:
-                valueFrom:
-                  secretKeyRef:
-                    name: sure-secret
-                    key: OPENAI_URI_BASE
-              OPENAI_ACCESS_TOKEN:
-                valueFrom:
-                  secretKeyRef:
-                    name: sure-secret
-                    key: OPENAI_ACCESS_TOKEN
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -42,7 +42,6 @@ spec:
               OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
               OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
-              OPENAI_ACCESS_TOKEN: "ollama"
               OPENAI_MODEL: "llama3.2:3b"
               AI_DEBUG_MODE: "true"
               SECRET_KEY_BASE:
@@ -70,6 +69,11 @@ spec:
                   secretKeyRef:
                     name: sure-secret
                     key: BRAND_FETCH_CLIENT_ID
+              OPENAI_ACCESS_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: sure-secret
+                    key: OPENAI_ACCESS_TOKEN
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/sure-secret.sops.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/sure-secret.sops.yaml
@@ -11,7 +11,7 @@ stringData:
   OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:FYg18fa1lx3zzHFtggKGOkUe1BjS7IePCTOLbuoSca0=,iv:0144AYOVeXnRI9sPWkE4v0ytkTSnFVfsImzYD7IRk4c=,tag:RqiVqFcjbjV8NXqeQK7E7Q==,type:str]
   BRAND_FETCH_CLIENT_ID: ENC[AES256_GCM,data:G6fUujGtcxWbQ2Koi2mpEGLNxQ==,iv:jfDiuyGzRPYn4kju43oyCzV74qwVR4oSA939z6LicNc=,tag:Gb9c2/ouonzzHkE9avPyig==,type:str]
   OPENAI_URI_BASE: ENC[AES256_GCM,data:my6zAmwcXeMQJD9FSqCosuYbjHWg6cGbdvjI7f+HiM5J,iv:8pgGQ/2eX/WKXXiqcMjQxYGySgSUdW4lLl9/eP94QtE=,tag:Aze4myXTn8mfyuHd5Wz46Q==,type:str]
-  OPENAI_ACCESS_TOKEN: ENC[AES256_GCM,data:k5J0DxHG7ksaBrsFhvt2xRRGdaa8siQ2A39vNZIAYknF6XQ=,iv:Pn2AQDjgz79NqY7FEL+IhmZfDtkmcwGar7zk+InPh38=,tag:f9EMCXhjqS+IGhMQnr6puw==,type:str]
+  OPENAI_ACCESS_TOKEN: ENC[AES256_GCM,data:Zn4SzjzD,iv:3tpl2fGQmQz2nNNGT0TaYQGY3JUVKWC6XNMZBKMiki8=,tag:DHmeiiGCqv21GJ1xO43gLg==,type:str]
 sops:
   age:
     - enc: |
@@ -24,6 +24,6 @@ sops:
         -----END AGE ENCRYPTED FILE-----
       recipient: age1kesma5f5dadlzdl5lzgrtxl6e8z8frf7njsfnlnprzan0lmzgdmstnd39u
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-05T20:34:12Z"
-  mac: ENC[AES256_GCM,data:l4GH6S4iRBvQrLx6AVvg5DUJ4/fzN6XG/59uHg9sOXIMOuthRvLjg2drVxmeRZink4Tn3Ts+wYyK5t+vKwwXYeZp/1Byg6+c97ZJUETIsozu0ArrVWKkKqRwJfRA4t4jEybpuRTbN4epCa1x3+Oor9Q8qlTOkwBqzf5ewrRJyoc=,iv:wiVUhgg/V3zAvylQwmI2WPicl9h/A/v8wz3MjfiqZ6U=,tag:eR1AnpONDpHtfkmW1bCzfQ==,type:str]
+  lastmodified: "2026-06-06T10:20:42Z"
+  mac: ENC[AES256_GCM,data:9Ntca6D6ORzrWku78VaTPQY7ohZ08oD6wk43biSAbLuZd0M4qT5C9sDQDl3dWHG8bi8RJugiOXbfCUXZ2h7g+jsRBNiNWUY/WkcfWl9ymtYQEZSzEiTdHUwFz7xuJd2WduNxuyOqneaq/vbg3C32uqP1bs7t61x0gUiPOEa6p7o=,iv:gRcbtw0y+dDhSchbYZe32cO8SCs9FHLr310BUymZrIM=,tag:Viq0k72/eFKzqahzsR5K7g==,type:str]
   version: 3.13.1


### PR DESCRIPTION
## Summary
- Point sure's OpenAI-compatible client at the in-cluster Ollama service (deployed in #546).
- Switch model from `qwen3.6-35b-a3b` to `llama3.2:3b`.
- Move `OPENAI_URI_BASE` and `OPENAI_ACCESS_TOKEN` out of the encrypted secret into plain env in `helmrelease.yaml` — the URL is now an in-cluster service DNS name and the token is a dummy (Ollama ignores it).
- Orphaned `OPENAI_URI_BASE` / `OPENAI_ACCESS_TOKEN` keys remain in `sure-secret.sops.yaml`; harmless, can be cleaned up later when convenient (requires SOPS_AGE_KEY).

## Test plan
- [x] `./scripts/validate.sh flux` passes
- [ ] After Flux reconciles, `sure` pod restarts (reloader picks up env change) and comes up Ready
- [ ] In sure UI, trigger a transaction categorization that uses the LLM and confirm a response (may take a few seconds on CPU inference)
- [ ] Check sure logs for any OpenAI client errors