### PR TITLE
fix(ai): cap ollama at 2 cpu cores

### DIFF
--- a/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
@@ -64,6 +64,7 @@ spec:
                 cpu: 500m
                 memory: 4Gi
               limits:
+                cpu: "2"
                 memory: 6Gi
         pod:
           securityContext:


### PR DESCRIPTION
## Summary
- Add `limits.cpu: "2"` to the ollama container so a single inference can't consume more than 2 cores.
- Inference still bursts up to the limit; requests remain at `500m`.

## Trade-off
- Caps token throughput at whatever 2 cores can deliver (~5-10 tok/s on llama3.2:3b). Acceptable for batch classification; may make interactive chat feel slower.

## Test plan
- [x] `./scripts/validate.sh flux` passes
- [ ] After Flux reconciles, pod restarts and `kubectl -n ai describe pod` shows `cpu: 2` under Limits
- [ ] A sample chat completion still returns a sensible response