### PR TITLE
feat(ai): switch ollama to qwen3.5:9b, pin to higher-CPU nodes, auto-unload idle models

### DIFF
--- a/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
@@ -23,7 +23,8 @@ spec:
               OLLAMA_HOST: "[::]:11434"
               OLLAMA_MODELS: /data/models
               HOME: /data
-              OLLAMA_KEEP_ALIVE: 24h
+              # Unload idle models after 5m so RAM is freed between requests; ollama auto-loads on next call.
+              OLLAMA_KEEP_ALIVE: 5m
               OLLAMA_MAX_LOADED_MODELS: "1"
               OLLAMA_NUM_PARALLEL: "2"
             probes:
@@ -61,17 +62,28 @@ spec:
                   failureThreshold: 60
             resources:
               requests:
-                cpu: 500m
-                memory: 4Gi
-              limits:
-                cpu: "2"
+                cpu: "1"
                 memory: 6Gi
+              limits:
+                cpu: "3"
+                memory: 8Gi
         pod:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
             fsGroup: 1000
             fsGroupChangePolicy: OnRootMismatch
+          # Pin to nodes with more CPU headroom; talos-1018-1 is excluded.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                          - talos-1018-2
+                          - talos-1018-3
 
     service:
       app:

--- a/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ollama-pull-llama3-2-3b
+  name: ollama-pull-qwen3-5-9b
 spec:
   backoffLimit: 6
   ttlSecondsAfterFinished: 86400
@@ -30,8 +30,8 @@ spec:
                 echo "Waiting for ollama service to be ready..."
                 sleep 5
               done
-              echo "Pulling llama3.2:3b..."
-              ollama pull llama3.2:3b
+              echo "Pulling qwen3.5:9b..."
+              ollama pull qwen3.5:9b
               echo "Done."
           resources:
             requests:

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
               OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
               OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
-              OPENAI_MODEL: "llama3.2:3b"
+              OPENAI_MODEL: "qwen3.5:9b"
               AI_DEBUG_MODE: "true"
               SECRET_KEY_BASE:
                 valueFrom:


### PR DESCRIPTION
## Summary
- Switch ollama from `llama3.2:3b` to `qwen3.5:9b` (and update `sure`'s `OPENAI_MODEL` to match)
- Raise ollama resources to requests `1 CPU / 6Gi`, limits `3 CPU / 8Gi`
- Pin ollama pod to `talos-1018-2` / `talos-1018-3` via `nodeAffinity` so it stays off the smaller `talos-1018-1`
- Drop `OLLAMA_KEEP_ALIVE` from `24h` to `5m` so the single loaded model unloads when idle and auto-reloads on the next request (`OLLAMA_MAX_LOADED_MODELS=1` keeps it strictly one-at-a-time)

## Test plan
- [ ] `flux reconcile kustomization apps --with-source` and confirm the `ollama` HelmRelease updates cleanly
- [ ] `kubectl -n ai get pods -o wide` shows the pod landing on `talos-1018-2` or `talos-1018-3`
- [ ] `kubectl -n ai logs job/ollama-pull-qwen3-5-9b` shows a successful pull of `qwen3.5:9b`
- [ ] `kubectl -n ai exec deploy/ollama -- ollama ps` — model present after a request, absent again after 5 min idle
- [ ] `sure` app issues a completion against the new model without error