### PR TITLE
fix(ai): fail ollama model-pull job on errors so Flux retries

### DIFF
--- a/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
@@ -24,6 +24,7 @@ spec:
               value: http://ollama.ai.svc.cluster.local:11434
           command:
             - /bin/sh
+            - -eu
             - -c
             - |
               until ollama list >/dev/null 2>&1; do
@@ -32,6 +33,8 @@ spec:
               done
               echo "Pulling qwen3.5:9b..."
               ollama pull qwen3.5:9b
+              echo "Verifying model is present..."
+              ollama list | grep -q '^qwen3\.5:9b\b'
               echo "Done."
           resources:
             requests:


### PR DESCRIPTION
## Summary
Today the `ollama-pull-qwen3-5-9b` Job hit a transient `unexpected EOF` mid-manifest-download and exited 0 anyway, because the inline `sh -c` script had no `set -e`. Result: `sure` was hitting ollama with a model the server didn't have, producing a flood of `404 POST /v1/chat/completions`.

- Run the script under `sh -eu` so any failing command (including `ollama pull`) fails the Job
- Add a post-pull `ollama list | grep` check so a malformed/empty pull is still surfaced
- Existing `backoffLimit: 6` then retries the pull on transient failures

(Already manually pulled `qwen3.5:9b` on the live cluster to unblock `sure` — this PR is the durability fix.)

## Test plan
- [ ] Delete the existing Job (`kubectl -n ai delete job ollama-pull-qwen3-5-9b`) so Flux recreates it from the new spec
- [ ] Confirm the Job completes successfully on the first try when the model is already present
- [ ] Simulate a failure (e.g. patch the script to `ollama pull nonexistent:tag`) and confirm the Job retries and eventually fails after `backoffLimit`