### PR TITLE
feat(ai): swap to llama3.2:3b + qwen2.5:7b, add Open WebUI with SSO

### DIFF
--- a/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
@@ -23,9 +23,8 @@ spec:
               OLLAMA_HOST: "[::]:11434"
               OLLAMA_MODELS: /data/models
               HOME: /data
-              # Unload idle models after 5m so RAM is freed between requests; ollama auto-loads on next call.
-              OLLAMA_KEEP_ALIVE: 5m
-              OLLAMA_MAX_LOADED_MODELS: "1"
+              OLLAMA_KEEP_ALIVE: 30m
+              OLLAMA_MAX_LOADED_MODELS: "2"
               OLLAMA_NUM_PARALLEL: "2"
             probes:
               liveness:

--- a/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ollama-pull-qwen3-5-9b
+  name: ollama-pull-models
 spec:
   backoffLimit: 6
   ttlSecondsAfterFinished: 86400
@@ -22,6 +22,8 @@ spec:
           env:
             - name: OLLAMA_HOST
               value: http://ollama.ai.svc.cluster.local:11434
+            - name: MODELS
+              value: "llama3.2:3b qwen2.5:7b"
           command:
             - /bin/sh
             - -eu
@@ -31,10 +33,12 @@ spec:
                 echo "Waiting for ollama service to be ready..."
                 sleep 5
               done
-              echo "Pulling qwen3.5:9b..."
-              ollama pull qwen3.5:9b
-              echo "Verifying model is present..."
-              ollama list | grep -q '^qwen3\.5:9b\b'
+              for model in $MODELS; do
+                echo "Pulling $model..."
+                ollama pull "$model"
+                echo "Verifying $model is present..."
+                ollama list | awk '{print $1}' | grep -Fxq "$model"
+              done
               echo "Done."
           resources:
             requests:

--- a/kubernetes/apps/talos1018/ai/openwebui/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/app/helmrelease.yaml
@@ -1,0 +1,142 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app openwebui
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 1h
+  values:
+    controllers:
+      openwebui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/open-webui/open-webui
+              # renovate: datasource=docker depName=ghcr.io/open-webui/open-webui
+              tag: 0.9.6
+            env:
+              PORT: "8080"
+              # Backend
+              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
+              WEBUI_URL: https://openwebui.${CLUSTER_DOMAIN}
+              # Disable local signups — auth via Pocket ID only
+              WEBUI_AUTH: "true"
+              ENABLE_SIGNUP: "false"
+              ENABLE_LOGIN_FORM: "false"
+              # OIDC / Pocket ID
+              ENABLE_OAUTH_SIGNUP: "true"
+              OAUTH_MERGE_ACCOUNTS_BY_EMAIL: "true"
+              OAUTH_PROVIDER_NAME: Pocket ID
+              OAUTH_SCOPES: openid email profile
+              OAUTH_USERNAME_CLAIM: preferred_username
+              OAUTH_EMAIL_CLAIM: email
+              OPENID_PROVIDER_URL: https://pid.${DOMAIN}/.well-known/openid-configuration
+              OPENID_REDIRECT_URI: https://openwebui.${CLUSTER_DOMAIN}/oauth/oidc/callback
+              WEBUI_SECRET_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: openwebui-secret
+                    key: WEBUI_SECRET_KEY
+              OAUTH_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: openwebui-secret
+                    key: OAUTH_CLIENT_ID
+              OAUTH_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: openwebui-secret
+                    key: OAUTH_CLIENT_SECRET
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  failureThreshold: 60
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        forceRename: *app
+        primary: true
+        controller: openwebui
+        ports:
+          http:
+            port: 8080
+
+    route:
+      app:
+        enabled: true
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: AI
+          gethomepage.dev/icon: open-webui.png
+          gethomepage.dev/name: Open WebUI
+          gethomepage.dev/app: openwebui
+          gethomepage.dev/description: Chat UI for local LLMs
+        parentRefs:
+          - name: main-gateway
+            namespace: network
+        hostnames:
+          - openwebui.${CLUSTER_DOMAIN}
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: app
+                port: 8080
+
+    persistence:
+      data:
+        existingClaim: openwebui-data
+        advancedMounts:
+          openwebui:
+            app:
+              - path: /app/backend/data

--- a/kubernetes/apps/talos1018/ai/openwebui/app/kustomization.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/app/kustomization.yaml
@@ -2,8 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: ai
 resources:
-  - ./namespace.yaml
-  - ./ocirepository.yaml
-  - ./ollama/ks.yaml
-  - ./openwebui/ks.yaml
+  - ./pvc.yaml
+  - ./openwebui-secret.sops.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/talos1018/ai/openwebui/app/openwebui-secret.sops.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/app/openwebui-secret.sops.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openwebui-secret
+type: Opaque
+stringData:
+  WEBUI_SECRET_KEY: ENC[AES256_GCM,data:GkTF0lKqxqNyUvluQgLTQiKnM7+prkcno8rp2sKX6bEBFmIMGc3u0nE1O5YfmC0nBwgiy/SNv0iWNVLoBOGlFYHDeJhVdbodCKnAKRt3d1xitmjw4C5NC/bUYT7Qi7Fm,iv:BD6557QB6j/bSH9ZdXN0hmFgN9UOXWukWt+5YCKUQZ0=,tag:vQU0VLlB2tHcDY86UeWJMQ==,type:str]
+  OAUTH_CLIENT_ID: ENC[AES256_GCM,data:lryTXSOXIPHFK7eUogOzPpfd1+Ex5ZjQ+/n5G0MXxc1MneP6,iv:rxH7GIBxcsOLZfnveXM5nldGseQM76EMgk0nEIbxS2g=,tag:rpMbTJQ0Jwf/BqTNiAloSA==,type:str]
+  OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:+HuILxLqRV9ByXZr/DVlJ6vwdzwAPw3WdoZXx25qTDY=,iv:z7IgmvTL/4f5toN4cg0LT/krqgiofl3l4jmvfI601WY=,tag:DKlByL8GcNwmWnQQf9iqqw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2SlJDU2M2RE5QaXpvdWdX
+        dk5SazdLVGxtUWdaNWlZYTd5SlFFM3FGUjBrCnNHQ28wVEhmcG83T0UvY29EcDF1
+        T1ZQOGFQWVFxcXhzU1BuM0p2K0VXZ28KLS0tIHRJZi9hQkMrNjlCclVmME1JNVFG
+        YmdrOHpkUUFKbTAvNFFwUUNkMW1weU0K9e6JcDkhWcILdiPeDej/qwrdqh40+nGe
+        uZuF1PduURzPWCKUNU8HN8hHlj3byGb8QXdzbucY9QIDju35C8bDqg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1kesma5f5dadlzdl5lzgrtxl6e8z8frf7njsfnlnprzan0lmzgdmstnd39u
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-14T16:34:35Z"
+  mac: ENC[AES256_GCM,data:zk6iGaOkDB9GvI7T0hyQTrhPscr63DiOf4U+cgdtWUG5evsyy0aPiXEV7Z1SUl6Fp+XIJ6C+niD/33kVIHb9ImyO7RVIYWp2/EATl+mn/Zn5vxw4U4UbPLQcxddag+O+X27EF5XXbwQ8wt+5CtLoeFGAwMMmtkeQPFgYHcaP1rY=,iv:DP92z6lIHOcU+LuYrxPFUDI5w5AAUmtLTaTZGJNwHpw=,tag:t00opw6Mfwt3NsPQVOsV1Q==,type:str]
+  version: 3.13.1

--- a/kubernetes/apps/talos1018/ai/openwebui/app/pvc.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/app/pvc.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kubernetes
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-data
+  labels:
+    recurring-job.longhorn.io/source: enabled
+    recurring-job.longhorn.io/daily-backup: enabled
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kubernetes/apps/talos1018/ai/openwebui/ks.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Open WebUI - ChatGPT-style frontend for the in-cluster Ollama
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openwebui
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-longhorn-config
+      namespace: flux-system
+    - name: ollama
+      namespace: flux-system
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  path: ./kubernetes/apps/talos1018/ai/openwebui/app
+  prune: true
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  wait: true

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
               OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
               OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
-              OPENAI_MODEL: "qwen3.5:9b"
+              OPENAI_MODEL: "qwen2.5:7b"
               AI_DEBUG_MODE: "true"
               SECRET_KEY_BASE:
                 valueFrom:


### PR DESCRIPTION
## Summary

- Drop `qwen3.5:9b` from Ollama — multimodal 9B was overwhelming the CPU and causing HA Assist requests to time out at ~5 min (prompt processing was ~5.88 tok/s on a ~5K-token HA prompt).
- Pull two models via the existing model-pull Job:
  - `llama3.2:3b` — for Home Assistant Assist (fast, native tool-calling).
  - `qwen2.5:7b` — for Sure (better instruction following / JSON output for AI categorization).
- Bump `OLLAMA_KEEP_ALIVE` 5m → 30m and `OLLAMA_MAX_LOADED_MODELS` 1 → 2 so HA and Sure don't evict each other (model fit at peak: ~2 GB + ~4.7 GB inside the 8 GiB pod limit).
- Sure: `OPENAI_MODEL` `qwen3.5:9b` → `qwen2.5:7b`.
- Add **Open WebUI** (`ghcr.io/open-webui/open-webui:0.9.6`) in the `ai` namespace:
  - Routed via `main-gateway` on the internal listener (hostname-routed).
  - **Pocket ID OIDC only** — local login form disabled, accounts auto-created on first SSO sign-in and merged by email.
  - 10 GiB Longhorn PVC (`/app/backend/data`) with daily backup labels.
  - Depends on the `ollama` Kustomization so reconcile order is correct.

## Manual steps after merge

- [x] Register the Open WebUI app in Pocket ID; redirect URI: `https://openwebui.<cluster-domain>/oauth/oidc/callback`.
- [x] Fill in `openwebui-secret.sops.yaml` with `WEBUI_SECRET_KEY` (`openssl rand -hex 48`) and the Pocket ID `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET`, then re-encrypt with SOPS. *(Already encrypted with placeholders — replace before merge.)*
- [ ] In the HA Ollama integration, switch the selected model to `llama3.2:3b`.
- [ ] First user to sign in to Open WebUI becomes admin; sign in yourself first.
- [ ] Optional cleanup once new models are pulled: `kubectl -n ai exec deploy/ollama -- ollama rm qwen3.5:9b` to reclaim ~5.3 GB.

## Test plan

- [ ] Flux reconciles `ollama` and `openwebui` Kustomizations green.
- [ ] `ollama-pull-models` Job completes; `ollama list` shows both `llama3.2:3b` and `qwen2.5:7b`.
- [ ] HA Assist responds to a simple query within HA's timeout.
- [ ] Sure chat returns a response (no more 404s on `/v1/chat/completions`).
- [ ] Sure transaction auto-categorization produces sensible categories.
- [ ] Open WebUI login redirects to Pocket ID, returns successfully, lands on the chat UI.
- [ ] Open WebUI lists both models and can chat against each.