### PR TITLE
fix(ai): make openwebui IPv6-only and extend startup probe

### DIFF
--- a/kubernetes/apps/talos1018/ai/openwebui/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/app/helmrelease.yaml
@@ -22,6 +22,8 @@ spec:
               # renovate: datasource=docker depName=ghcr.io/open-webui/open-webui
               tag: 0.9.6
             env:
+              # uvicorn binds HOST:PORT; "::" → IPv6 (cluster is IPv6-primary).
+              HOST: "::"
               PORT: "8080"
               # Backend
               OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
@@ -107,6 +109,8 @@ spec:
         forceRename: *app
         primary: true
         controller: openwebui
+        ipFamilyPolicy: SingleStack
+        ipFamilies: [IPv6]
         ports:
           http:
             port: 8080

--- a/kubernetes/apps/talos1018/ai/openwebui/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/openwebui/app/helmrelease.yaml
@@ -84,9 +84,11 @@ spec:
                   httpGet:
                     path: /health
                     port: 8080
-                  initialDelaySeconds: 10
-                  periodSeconds: 5
-                  failureThreshold: 60
+                  # First run downloads ~1 GB of sentence-transformers weights from HF
+                  # into the PVC; restarts still need ~2 min to load embeddings. 20 min cap.
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 120
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
## Summary

Two compounding reasons openwebui never went Ready after #571:

1. **IPv6 binding (root cause)** — uvicorn defaults to `HOST=0.0.0.0` (IPv4 only), but kubelet probes the pod's IPv6 address; result: `connect: connection refused`. Set `HOST=::` so uvicorn binds IPv6, and pin the Service to `SingleStack` / `IPv6` to match the rest of the cluster.
2. **Startup time** — first-run startup downloads ~1 GB of sentence-transformers weights from HuggingFace into the PVC. The previous 5-min probe budget would have killed the pod even once IPv6 worked. Bumped startup probe to 20-min cap (30s initial delay + 120 × 10s) — covers first-run downloads and ~2-min embedding loads on subsequent restarts.

Note: the `permission denied: /app/backend/open_webui/static/*.png` errors in the logs are unrelated and non-fatal — a startup helper wants to refresh image-baked icons but we run as UID 1000 while those files are root-owned. App continues past them.

## Test plan

- [ ] Pod transitions to Ready within ~10-15 min of first start.
- [ ] Service has only an IPv6 cluster IP.
- [ ] `/health` returns 200 on the pod's IPv6 address.
- [ ] Subsequent restarts come up in ~2 min (weights cached on PVC).
- [ ] UI loads at `https://openwebui.<cluster-domain>`.