### PR TITLE
feat(ai): consolidate ollama on llama3.2:3b

### DIFF
--- a/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
@@ -23,8 +23,8 @@ spec:
               OLLAMA_HOST: "[::]:11434"
               OLLAMA_MODELS: /data/models
               HOME: /data
-              OLLAMA_KEEP_ALIVE: 30m
-              OLLAMA_MAX_LOADED_MODELS: "2"
+              OLLAMA_KEEP_ALIVE: "-1"
+              OLLAMA_MAX_LOADED_MODELS: "1"
               OLLAMA_NUM_PARALLEL: "2"
             probes:
               liveness:

--- a/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
@@ -23,7 +23,7 @@ spec:
             - name: OLLAMA_HOST
               value: http://ollama.ai.svc.cluster.local:11434
             - name: MODELS
-              value: "llama3.2:3b qwen2.5:7b"
+              value: "llama3.2:3b"
           command:
             - /bin/sh
             - -eu
@@ -38,6 +38,8 @@ spec:
                 ollama pull "$model"
                 echo "Verifying $model is present..."
                 ollama list | awk '{print $1}' | grep -Fxq "$model"
+                echo "Preloading $model into memory..."
+                ollama run "$model" "" >/dev/null 2>&1 || true
               done
               echo "Done."
           resources:

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
               OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
               OPENAI_URI_BASE: "http://ollama.ai.svc.cluster.local:11434/v1"
-              OPENAI_MODEL: "qwen2.5:7b"
+              OPENAI_MODEL: "llama3.2:3b"
               AI_DEBUG_MODE: "true"
               SECRET_KEY_BASE:
                 valueFrom:


### PR DESCRIPTION
Remove qwen2.5:7b and standardize on llama3.2:3b.

- Pull only llama3.2:3b and preload it into memory
- `OLLAMA_KEEP_ALIVE=-1` so the model never unloads; `OLLAMA_MAX_LOADED_MODELS=1`
- Point the `sure` app at llama3.2:3b