### PR TITLE
feat: switch Sure AI to in-cluster ollama (llama3.1:8b)

### DIFF
--- a/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
               HOME: /data
               OLLAMA_KEEP_ALIVE: "-1"
               OLLAMA_MAX_LOADED_MODELS: "1"
-              OLLAMA_NUM_PARALLEL: "2"
+              OLLAMA_NUM_PARALLEL: "1"
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
+++ b/kubernetes/apps/talos1018/ai/ollama/app/model-pull-job.yaml
@@ -23,7 +23,7 @@ spec:
             - name: OLLAMA_HOST
               value: http://ollama.ai.svc.cluster.local:11434
             - name: MODELS
-              value: "llama3.2:3b"
+              value: "llama3.1:8b"
           command:
             - /bin/sh
             - -eu

--- a/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
+++ b/kubernetes/apps/talos1018/self-hosted/sure/app/helmrelease.yaml
@@ -41,8 +41,8 @@ spec:
               AUTH_LOCAL_ADMIN_OVERRIDE_ENABLED: "true"
               OIDC_ISSUER: https://pid.${DOMAIN}
               OIDC_REDIRECT_URI: https://sure.${CLUSTER_DOMAIN}/auth/openid_connect/callback
-              OPENAI_URI_BASE: http://ollama.home.:1234/v1
-              OPENAI_MODEL: "openai/gpt-oss-20b"
+              OPENAI_URI_BASE: http://ollama.ai.svc.cluster.local:11434/v1
+              OPENAI_MODEL: "llama3.1:8b"
               AI_DEBUG_MODE: "true"
               SECRET_KEY_BASE:
                 valueFrom:


### PR DESCRIPTION
## Summary
Repoints Sure's AI features at the in-cluster Ollama using `llama3.1:8b`, and tunes Ollama for the CPU-only node limits.

Smaller instruct models (`llama3.2:3b`, `qwen2.5:7b`) and the reasoning-style `qwen3.6-35b-a3b` failed at the two things every Sure AI feature needs — OpenAI-style **function/tool calling** (Chat) and **strict `json_schema` structured output** (auto-categorize / detect-merchants). The reasoning model also leaked `<think>` tokens that broke the chat parser. `llama3.1:8b` is the smallest tier that does both reliably and still fits the node.

## Verification (probed against the live endpoint)
- ✅ Tool calling: clean `tool_calls`, correct function name + valid JSON args, no reasoning leakage
- ✅ Strict `json_schema` output: valid JSON matching schema
- ✅ Footprint: 6.2 GB loaded (model + KV cache), pod RSS ~6.0 Gi vs 8 Gi limit

## Changes
- `feat(ai)`: pull-job pulls `llama3.1:8b`; `OLLAMA_NUM_PARALLEL` 2 → 1 (halves KV-cache allocation, avoids core contention under 3 CPU / 8 Gi)
- `feat(sure)`: `OPENAI_URI_BASE` back to in-cluster ollama service, `OPENAI_MODEL: llama3.1:8b`

## Note
CPU-only inference (~3–6 tok/s) — AI operations take ~30–90s, slower than the previous Mac-hosted gpt-oss-20b but self-contained.