### PR TITLE
ci(github-action): unpin actions from commit digests, track version tags

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@01872ccc02bf66740207fb338a783ce028216758 # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@01872ccc02bf66740207fb338a783ce028216758 # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/flux-e2e.yaml
+++ b/.github/workflows/flux-e2e.yaml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
       - name: Setup Flux
-        uses: fluxcd/flux2/action@006ecb6b0401525e703585df9e87d6d0d2ed34bd # main
+        uses: fluxcd/flux2/action@main
       - name: Setup Kubernetes
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        uses: helm/kind-action@v1.14.0
         with:
           cluster_name: flux
       - name: Install Flux in Kubernetes Kind

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -11,9 +11,9 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      - uses: gitleaks/gitleaks-action@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-flux.yaml
+++ b/.github/workflows/validate-flux.yaml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
       - name: Setup yq
-        uses: fluxcd/pkg/actions/yq@61592eceb249333f745e349eb2da9e2a684b8585 # main
+        uses: fluxcd/pkg/actions/yq@main
       - name: Setup kubeconform
-        uses: fluxcd/pkg/actions/kubeconform@61592eceb249333f745e349eb2da9e2a684b8585 # main
+        uses: fluxcd/pkg/actions/kubeconform@main
       - name: Setup kustomize
-        uses: fluxcd/pkg/actions/kustomize@61592eceb249333f745e349eb2da9e2a684b8585 # main
+        uses: fluxcd/pkg/actions/kustomize@main
       - name: Setup yamllint
         run: pip install yamllint
       - name: Validate manifests

--- a/.github/workflows/validate-talos.yaml
+++ b/.github/workflows/validate-talos.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@v7
 
       - name: Install Talos CLI
         run: |

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     "docker:enableMajor",
-    "helpers:pinGitHubActionDigests",
     "local>fmurodov/homeops//.renovate/autoMerge.json5",
     "local>fmurodov/homeops//.renovate/changelogs.json5",
     "local>fmurodov/homeops//.renovate/customManagers.json5",


### PR DESCRIPTION
## Summary
- Remove the `helpers:pinGitHubActionDigests` Renovate preset so GitHub Actions are no longer pinned to full commit SHAs.
- Rewrite all `uses:` lines in `.github/workflows/*` to bare version tags (e.g. `actions/checkout@v7`) instead of `@<sha> # v7`. Actions without semver releases (fluxcd's composite actions) now reference `@main` directly.

## Why
Digest-pinned GitHub Actions were generating noisy "digest" update PRs/commits (SHA-only bumps with no real version change), especially for `fluxcd/flux2/action` and `fluxcd/pkg/actions/*`, which track the `main` branch. Renovate will now only open PRs for genuine version releases.

## Note for reviewer
- `fluxcd/flux2/action`, `fluxcd/pkg/actions/yq`, `fluxcd/pkg/actions/kubeconform`, and `fluxcd/pkg/actions/kustomize` don't publish semver tags, so with digest pinning removed Renovate has nothing to track for these anymore — no more automatic updates for those four until/unless they cut real tags.

## Test plan
- [x] `./scripts/validate.sh flux` passes
- [x] Pre-commit hook validation passed on commit